### PR TITLE
feat(ai-tabs): close tab on middle click

### DIFF
--- a/src/components/ai/TabButton.tsx
+++ b/src/components/ai/TabButton.tsx
@@ -47,6 +47,9 @@ export function TabButton({ tab, isActive, onActivate, onClose, onRename }: TabB
 					? "bg-background border border-b-background border-border -mb-px"
 					: "text-muted-foreground"
 			}`}
+			onAuxClick={(e) => {
+				if (e.button === 1) onClose();
+			}}
 		>
 			{editing ? (
 				<input


### PR DESCRIPTION
## Summary

- Adds `onAuxClick` handler to the `TabButton` wrapper `div` so that middle-clicking (mouse button 1) closes the tab, matching the UX convention found in browsers and most tabbed interfaces.

## Test plan

- [ ] Open the AI page with multiple tabs open
- [ ] Middle-click a tab — it should close immediately
- [ ] Verify left-click still activates the tab and the X button still closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)