### PR TITLE
fix: move scroll from tab bar to terminal content area

### DIFF
--- a/src/components/ai/TabBar.tsx
+++ b/src/components/ai/TabBar.tsx
@@ -14,7 +14,7 @@ interface TabBarProps {
 
 export function TabBar({ tabs, activeTabId, onActivate, onClose, onRename, onAdd }: TabBarProps) {
 	return (
-		<div className="flex items-center gap-1 px-2 pt-1 border-b border-border shrink-0 overflow-x-auto">
+		<div className="flex items-center gap-1 px-2 pt-1 border-b border-border shrink-0 overflow-hidden">
 			{tabs.map((tab) => (
 				<TabButton
 					key={tab.id}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -50,7 +50,7 @@ export function SettingsPage() {
 	};
 
 	return (
-		<div className="p-6 max-w-lg flex flex-col gap-6">
+		<div className="h-full overflow-auto p-6 max-w-lg flex flex-col gap-6">
 			<div>
 				<h1 className="text-lg font-semibold">Settings</h1>
 				<p className="mt-1 text-sm text-muted-foreground font-mono">{workspace.path}</p>

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -1,6 +1,6 @@
 export function TasksPage() {
 	return (
-		<div className="p-6">
+		<div className="h-full overflow-auto p-6">
 			<h1 className="text-lg font-semibold">Tasks</h1>
 			<p className="mt-2 text-sm text-muted-foreground">
 				Current and recent agent work will appear here.

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -29,7 +29,7 @@ function WorkspaceLayout() {
 	return (
 		<>
 			<Sidebar />
-			<main className="flex-1 overflow-auto">
+			<main className="flex-1 overflow-hidden">
 				<Outlet />
 			</main>
 		</>


### PR DESCRIPTION
## Summary

- Removes `overflow-x-auto` from `TabBar` — the tab strip no longer shows a horizontal scrollbar
- Changes `<main>` in `WorkspaceLayout` from `overflow-auto` to `overflow-hidden` — this is the root cause: the outer scroll container was preventing `AiPage` from being height-constrained, which meant xterm.js never properly filled the viewport and mouse-wheel scrollback didn't work
- Adds `h-full overflow-auto` to `SettingsPage` and `TasksPage` so they remain scrollable inside the now-constrained `<main>`

With these changes, the terminal content area fills the screen correctly and xterm.js scrollback (`scrollback: 5000`) handles conversation history via mouse wheel.

## Test plan

- [ ] AI tab: no horizontal scrollbar in the tab bar
- [ ] AI tab: mouse wheel scrolls through terminal history (xterm scrollback)
- [ ] Settings page: still scrolls vertically if content overflows
- [ ] Tasks page: still scrolls vertically if content overflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)