### PR TITLE
fix: open terminal links in system browser

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -2,6 +2,7 @@ import { Terminal as XTerm, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffect, useRef } from "react";
 import {
 	ptyKill,
@@ -99,7 +100,7 @@ export function Terminal({ id, program, args, cwd, isActive }: TerminalProps) {
 			cursorBlink: true,
 		});
 		const fitAddon = new FitAddon();
-		const webLinksAddon = new WebLinksAddon();
+		const webLinksAddon = new WebLinksAddon((_event, url) => openUrl(url));
 
 		term.loadAddon(fitAddon);
 		term.loadAddon(webLinksAddon);


### PR DESCRIPTION
## Summary

- `WebLinksAddon` (already loaded in the terminal) defaults to `window.open()` — Tauri intercepts that and opens the URL inside the webview instead of the system browser
- Pass `openUrl` from `@tauri-apps/plugin-opener` (already a dependency) as the click handler, so Ctrl/Cmd+clicking a URL in the terminal opens it in the default browser

```diff
-const webLinksAddon = new WebLinksAddon();
+const webLinksAddon = new WebLinksAddon((_event, url) => openUrl(url));
```

## General pattern for external links in this app

For any external links added to the React UI in future, the same rule applies: **never use bare `<a href="https://...">` tags** — they navigate the webview. Instead use a `<button>` or `<span>` with an `onClick` that calls `openUrl(url)` from `plugin-opener`.

Internal navigation (between app routes) uses TanStack Router's `<Link>` as normal.

## Test plan

- [ ] Ctrl+click (or click) a URL printed in the terminal — it should open in the system browser
- [ ] Internal route navigation still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)