### PR TITLE
fix: capture terminal output and clean up tool call UI

### DIFF
--- a/src/components/ai/chat/ToolCallCard.tsx
+++ b/src/components/ai/chat/ToolCallCard.tsx
@@ -27,7 +27,7 @@ export function ToolCallCard({ title, status, output }: ToolCallCardProps) {
 			<button
 				type="button"
 				className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-muted/50 transition-colors text-left"
-				onClick={() => setExpanded((v) => !v)}
+				onClick={() => output && setExpanded((v) => !v)}
 			>
 				<StatusIcon
 					className={cn(
@@ -38,12 +38,14 @@ export function ToolCallCard({ title, status, output }: ToolCallCardProps) {
 				/>
 				<Terminal className="size-3.5 shrink-0 text-muted-foreground" />
 				<span className="flex-1 font-mono text-xs truncate text-foreground">{title}</span>
-				<ChevronRight
-					className={cn(
-						"size-3.5 shrink-0 text-muted-foreground transition-transform",
-						expanded && "rotate-90"
-					)}
-				/>
+				{output && (
+					<ChevronRight
+						className={cn(
+							"size-3.5 shrink-0 text-muted-foreground transition-transform",
+							expanded && "rotate-90"
+						)}
+					/>
+				)}
 			</button>
 
 			{expanded && output && (

--- a/src/hooks/useAcpSession.ts
+++ b/src/hooks/useAcpSession.ts
@@ -241,7 +241,24 @@ export function useAcpSession(opts: UseAcpSessionOptions): UseAcpSessionResult {
 
         case "tool_call": {
           setMessages((prev) => {
-            // Close any in-progress assistant message first
+            // If a card with this ID already exists, update it in-place.
+            const existingIdx = prev.findIndex(
+              (m) => m.type === "tool_call" && m.id === kind.id,
+            );
+            if (existingIdx >= 0) {
+              const next = [...prev];
+              const existing = next[existingIdx] as Extract<
+                ConversationMessage,
+                { type: "tool_call" }
+              >;
+              next[existingIdx] = {
+                ...existing,
+                title: kind.title || existing.title,
+                status: kind.status,
+              };
+              return next;
+            }
+            // New tool call — close any in-progress assistant message first.
             const closed = closePendingAssistant(prev);
             return [
               ...closed,

--- a/src/services/acpService.ts
+++ b/src/services/acpService.ts
@@ -298,8 +298,9 @@ async function spawnAndConnect(
 			async createTerminal(params) {
 				// Use a unique terminal ID scoped to this connection
 				const terminalId = `acp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-				// Spawn a PTY with a minimal size; it runs headlessly for the agent
-				await ptySpawn(terminalId, params.command, params.args ?? [], params.cwd ?? cwd, 24, 80);
+				// The ACP adapter passes the full shell command string in params.command with no args.
+				// Run it through /bin/sh -c so that arguments, pipes, and shell syntax work.
+				await ptySpawn(terminalId, "/bin/sh", ["-c", params.command], params.cwd ?? cwd, 24, 80);
 				return { terminalId };
 			},
 

--- a/src/services/acpService.ts
+++ b/src/services/acpService.ts
@@ -58,6 +58,21 @@ export interface AcpSessionHandle {
 const sessions = new Map<string, AcpSessionHandleImpl>();
 
 // ---------------------------------------------------------------------------
+// Terminal output buffer
+// Listeners are registered immediately on spawn so no output is missed,
+// even if the process exits before terminalOutput() is called.
+// ---------------------------------------------------------------------------
+
+interface TerminalBuffer {
+	chunks: string[];
+	closed: boolean;
+	closeResolvers: Array<() => void>;
+	unlistenData: (() => void) | null;
+}
+
+const terminalBuffers = new Map<string, TerminalBuffer>();
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -298,6 +313,31 @@ async function spawnAndConnect(
 			async createTerminal(params) {
 				// Use a unique terminal ID scoped to this connection
 				const terminalId = `acp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+				// Set up the buffer and register the data listener BEFORE spawning so no
+				// pty-data events are missed for fast-exiting commands.
+				const buf: TerminalBuffer = {
+					chunks: [],
+					closed: false,
+					closeResolvers: [],
+					unlistenData: null,
+				};
+				terminalBuffers.set(terminalId, buf);
+
+				const dec = new TextDecoder();
+				buf.unlistenData = await ptyOnData(terminalId, (data) => {
+					buf.chunks.push(dec.decode(data));
+				});
+
+				// Wire close events into the buffer so terminalOutput/waitForTerminalExit
+				// resolve correctly even when close fires before they're called.
+				// ptyOnClose is already backed by a buffered module-level listener (see ptyService.ts).
+				await ptyOnClose(terminalId, () => {
+					buf.closed = true;
+					for (const resolve of buf.closeResolvers) resolve();
+					buf.closeResolvers = [];
+				});
+
 				// The ACP adapter passes the full shell command string in params.command with no args.
 				// Run it through /bin/sh -c so that arguments, pipes, and shell syntax work.
 				await ptySpawn(terminalId, "/bin/sh", ["-c", params.command], params.cwd ?? cwd, 24, 80);
@@ -305,50 +345,31 @@ async function spawnAndConnect(
 			},
 
 			async terminalOutput(params) {
-				// Collect all buffered output from ptyService events
-				// Since ptyService is event-based, we accumulate output via a promise
+				const buf = terminalBuffers.get(params.terminalId);
+				if (!buf) {
+					return { output: "", truncated: false };
+				}
+
+				// If already closed, return accumulated output immediately.
+				if (buf.closed) {
+					return { output: stripAnsi(buf.chunks.join("")), truncated: false, exitStatus: { exitCode: 0 } };
+				}
+
+				// Otherwise wait for close.
 				return new Promise((resolve) => {
-					let output = "";
-					let settled = false;
-
-					const unlisten = ptyOnData(params.terminalId, (data) => {
-						output += new TextDecoder().decode(data);
+					buf.closeResolvers.push(() => {
+						resolve({ output: stripAnsi(buf.chunks.join("")), truncated: false, exitStatus: { exitCode: 0 } });
 					});
-
-					// ptyOnClose signals exit — resolve then
-					const unlistenClose = ptyOnClose(params.terminalId, () => {
-						if (!settled) {
-							settled = true;
-							Promise.all([unlisten, unlistenClose]).then(([ul, ulc]) => {
-								ul();
-								ulc();
-							});
-							resolve({ output, truncated: false, exitStatus: { exitCode: 0 } });
-						}
-					});
-
-					// Fallback: if close never fires, resolve after a short poll
-					setTimeout(() => {
-						if (!settled) {
-							settled = true;
-							Promise.all([unlisten, unlistenClose]).then(([ul, ulc]) => {
-								ul();
-								ulc();
-							});
-							resolve({ output, truncated: false });
-						}
-					}, 100);
 				});
 			},
 
 			async waitForTerminalExit(params) {
+				const buf = terminalBuffers.get(params.terminalId);
+				if (!buf || buf.closed) {
+					return { exitCode: 0 };
+				}
 				return new Promise((resolve) => {
-					ptyOnClose(params.terminalId, () => {
-						resolve({ exitCode: 0 });
-					}).then((unlisten) => {
-						// The unlisten is captured when needed
-						void unlisten;
-					});
+					buf.closeResolvers.push(() => resolve({ exitCode: 0 }));
 				});
 			},
 
@@ -358,6 +379,11 @@ async function spawnAndConnect(
 			},
 
 			async releaseTerminal(params) {
+				const buf = terminalBuffers.get(params.terminalId);
+				if (buf) {
+					buf.unlistenData?.();
+					terminalBuffers.delete(params.terminalId);
+				}
 				await ptyKill(params.terminalId);
 			},
 		};
@@ -431,12 +457,38 @@ function notificationToEvents(notification: SessionNotification): AgentEventKind
 			const tcu = update as unknown as {
 				toolCallId?: string;
 				status?: string;
+				// ACP-style content blocks (used by most tools)
+				content?: Array<{ type: string; content?: { content?: { type: string; text?: string } } }>;
+				// Anthropic API format (used by mcp__acp__Bash via rawOutput)
+				rawOutput?: unknown;
 			};
+
+			let content: string | undefined;
+
+			// ACP content blocks: { type: "content", content: { content: { type: "text", text } } }
+			if (Array.isArray(tcu.content) && tcu.content.length > 0) {
+				const texts = tcu.content
+					.filter((c) => c.type === "content" && c.content?.content?.type === "text")
+					.map((c) => c.content?.content?.text ?? "")
+					.filter(Boolean);
+				if (texts.length > 0) content = texts.join("\n");
+			}
+
+			// rawOutput fallback: Anthropic API array [{ type: "text", text }]
+			// Used by mcp__acp__Bash since toolUpdateFromToolResult returns {} for it.
+			if (!content && Array.isArray(tcu.rawOutput)) {
+				const texts = (tcu.rawOutput as Array<{ type?: string; text?: string }>)
+					.filter((c) => c.type === "text" && c.text)
+					.map((c) => c.text ?? "");
+				if (texts.length > 0) content = texts.join("\n");
+			}
+
 			return [
 				{
 					type: "tool_call_update",
 					id: tcu.toolCallId ?? "",
 					status: mapToolStatus(tcu.status),
+					...(content !== undefined ? { content } : {}),
 				},
 			];
 		}
@@ -461,6 +513,29 @@ function notificationToEvents(notification: SessionNotification): AgentEventKind
 		default:
 			return [];
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Strip ANSI/VT escape sequences from PTY output
+//
+// PTY output is raw terminal data and includes:
+//   - SGR color codes:  ESC [ <params> m
+//   - CSI sequences:    ESC [ <params> <final>
+//   - OSC sequences:    ESC ] <text> BEL  or  ESC ] <text> ESC \
+//   - Other ESC codes:  ESC <char>
+// ---------------------------------------------------------------------------
+
+// Matches all common VT/ANSI escape sequences.
+// Order matters: OSC (ESC]) must be checked before the single-char fallback ([@-Z\\-_])
+// because `]` (0x5D) falls in the \\-_ range and would otherwise be consumed alone,
+// leaving the OSC payload (e.g. "11;?") behind.
+// The OSC terminator (BEL or ESC\) is made optional to handle unterminated queries
+// such as ESC]11;? (terminal background-color query) that have no response in a headless PTY.
+const ANSI_ESCAPE_RE =
+	/[\x1b\x9b](?:\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)?|[@-Z\\-_])/g;
+
+function stripAnsi(text: string): string {
+	return text.replace(ANSI_ESCAPE_RE, "");
 }
 
 function mapToolStatus(status: string | undefined): ToolCallStatus {

--- a/src/services/ptyService.ts
+++ b/src/services/ptyService.ts
@@ -32,10 +32,42 @@ export async function ptyOnData(id: string, cb: (data: Uint8Array) => void): Pro
 	});
 }
 
+// ---------------------------------------------------------------------------
+// ptyOnClose — buffered so late registrations still fire
+//
+// Commands spawned via /bin/sh -c can complete before waitForTerminalExit
+// registers its Tauri event listener.  A single module-level listener buffers
+// close events so that any callback registered after the close still fires.
+// ---------------------------------------------------------------------------
+
+const closedPtyIds = new Set<string>();
+const closeCallbackRegistry = new Map<string, Set<() => void>>();
+
+// Eagerly register the single global listener.
+// Tauri events fire on the main thread; module-level side effects are fine here.
+listen<{ id: string }>("pty-close", (event) => {
+	const id = event.payload.id;
+	closedPtyIds.add(id);
+	const callbacks = closeCallbackRegistry.get(id);
+	if (callbacks) {
+		closeCallbackRegistry.delete(id);
+		for (const cb of callbacks) cb();
+	}
+});
+
 export async function ptyOnClose(id: string, cb: () => void): Promise<() => void> {
-	return listen<{ id: string }>("pty-close", (event) => {
-		if (event.payload.id === id) {
-			cb();
-		}
-	});
+	if (closedPtyIds.has(id)) {
+		// Already closed — invoke the callback asynchronously to keep callers consistent.
+		queueMicrotask(cb);
+		return () => {};
+	}
+	let set = closeCallbackRegistry.get(id);
+	if (!set) {
+		set = new Set();
+		closeCallbackRegistry.set(id, set);
+	}
+	set.add(cb);
+	return () => {
+		closeCallbackRegistry.get(id)?.delete(cb);
+	};
 }


### PR DESCRIPTION
## Summary

- **Fix missing terminal output**: `pty-data` events were registered in `terminalOutput()` — after `createTerminal()` already spawned the process. Fast commands like `gh auth status` would exit before the listener existed, dropping all output. Now a buffer is set up immediately on spawn so no bytes are missed.
- **Surface output in UI**: `tool_call_update` notifications weren't having their content extracted. Added extraction from both ACP content blocks and the `rawOutput` fallback used by `mcp__acp__Bash`.
- **Fix ANSI stripping**: Added `stripAnsi()` for PTY output. Fixed a regex ordering bug where `ESC]` was consumed as a 2-char single-char escape (leaving `11;?` behind) instead of being matched as a full OSC sequence.
- **Deduplicate tool call cards**: `tool_call` events now upsert by ID rather than always appending, preventing duplicate cards for the same tool call.
- **Hide chevron when no output**: `ToolCallCard` no longer shows the expand/collapse chevron until there is output to display.

## Test plan

- [ ] Run a bash command (e.g. `gh auth status`) and verify output appears in the tool call card
- [ ] Confirm no ANSI artifacts in the output (no `11;?` prefix, no color codes)
- [ ] Confirm only one tool call card appears per command (no duplicates)
- [ ] Confirm the expand chevron is absent while a command is loading and appears once output arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)