### PR TITLE
feat: GitHub Projects connector (#9)

### DIFF
--- a/src/services/__tests__/github-auth.test.ts
+++ b/src/services/__tests__/github-auth.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock @tauri-apps/plugin-store before importing the module under test
+// ---------------------------------------------------------------------------
+
+const storeData: Record<string, unknown> = {};
+
+const mockGet = mock((key: string) => Promise.resolve(storeData[key] ?? null));
+const mockSet = mock((key: string, value: unknown) => {
+	storeData[key] = value;
+	return Promise.resolve();
+});
+
+mock.module("@tauri-apps/plugin-store", () => ({
+	LazyStore: class {
+		get = mockGet;
+		set = mockSet;
+	},
+}));
+
+const { getGitHubToken, setGitHubToken, hasGitHubToken } = await import("../github-auth");
+
+beforeEach(() => {
+	for (const key of Object.keys(storeData)) {
+		delete storeData[key];
+	}
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("hasGitHubToken returns false on fresh install", async () => {
+	const result = await hasGitHubToken();
+	expect(result).toBe(false);
+});
+
+test("getGitHubToken returns null when no token stored", async () => {
+	const result = await getGitHubToken();
+	expect(result).toBeNull();
+});
+
+test("round-trip: setGitHubToken then getGitHubToken returns same value", async () => {
+	await setGitHubToken("ghp_testtoken123");
+	const result = await getGitHubToken();
+	expect(result).toBe("ghp_testtoken123");
+});
+
+test("hasGitHubToken returns true after setting a token", async () => {
+	await setGitHubToken("ghp_testtoken123");
+	const result = await hasGitHubToken();
+	expect(result).toBe(true);
+});
+
+test("error messages contain no token value", async () => {
+	const faultyStore = mock(() => {
+		throw new Error("internal storage failure");
+	});
+	const originalGet = mockGet.mockImplementation(faultyStore);
+
+	let errorMessage = "";
+	try {
+		await getGitHubToken();
+	} catch (e) {
+		errorMessage = e instanceof Error ? e.message : String(e);
+	}
+
+	mockGet.mockImplementation(originalGet);
+
+	expect(errorMessage).not.toContain("ghp_");
+	expect(errorMessage.length).toBeGreaterThan(0);
+});

--- a/src/services/__tests__/github-projects.test.ts
+++ b/src/services/__tests__/github-projects.test.ts
@@ -1,0 +1,506 @@
+import { beforeEach, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock @/services/github-auth before importing module under test.
+// Mocking the direct dependency (rather than the Tauri plugin two hops away)
+// avoids module-cache cross-contamination when the full test suite runs.
+// ---------------------------------------------------------------------------
+
+let _mockToken: string | null = null;
+
+mock.module("@/services/github-auth", () => ({
+	getGitHubToken: () => Promise.resolve(_mockToken),
+}));
+
+// ---------------------------------------------------------------------------
+// Import modules under test after mocks are registered
+// ---------------------------------------------------------------------------
+
+const {
+	GitHubProjectsSource,
+	GitHubAuthError,
+	GitHubNetworkError,
+	fetchGitHubIssue,
+} = await import("../github-projects");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setToken(token: string | null) {
+	_mockToken = token;
+}
+
+const BASE_REPO_SETTINGS = {
+	repo: "testowner/testrepo",
+	github_project_number: 42,
+};
+
+function makeIssueNode(
+	overrides: {
+		id?: string;
+		contentType?: string;
+		number?: number;
+		title?: string;
+		body?: string | null;
+		state?: string;
+		url?: string;
+		labels?: string[];
+		milestone?: { number: number; title: string } | null;
+	} = {},
+): Record<string, unknown> {
+	const {
+		id = "item_001",
+		contentType = "Issue",
+		number = 1,
+		title = "Test issue",
+		body = "Issue body",
+		state = "open",
+		url = "https://github.com/testowner/testrepo/issues/1",
+		labels = [],
+		milestone = null,
+	} = overrides;
+
+	if (contentType !== "Issue") {
+		return { id, content: { __typename: contentType } };
+	}
+
+	return {
+		id,
+		content: {
+			__typename: "Issue",
+			number,
+			title,
+			body,
+			state,
+			url,
+			labels: { nodes: labels.map((name) => ({ name })) },
+			milestone,
+		},
+	};
+}
+
+function makePageResponse(
+	nodes: Record<string, unknown>[],
+	hasNextPage = false,
+	endCursor = "cursor_end",
+): Record<string, unknown> {
+	const projectData = {
+		id: "project_id_001",
+		items: {
+			pageInfo: { hasNextPage, endCursor },
+			nodes,
+		},
+	};
+	return {
+		data: {
+			organization: { projectV2: projectData },
+			user: null,
+		},
+	};
+}
+
+function makeStatusFieldResponse(
+	options: Array<{ id: string; name: string }>,
+): Record<string, unknown> {
+	return {
+		data: {
+			organization: {
+				projectV2: {
+					id: "project_id_001",
+					field: {
+						id: "field_status_001",
+						options,
+					},
+				},
+			},
+			user: null,
+		},
+	};
+}
+
+function makeTransitionMutationResponse(): Record<string, unknown> {
+	return {
+		data: {
+			updateProjectV2ItemFieldValue: {
+				projectV2Item: { id: "item_001" },
+			},
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let fetchCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+
+beforeEach(() => {
+	_mockToken = null;
+	fetchCalls = [];
+	globalThis.fetch = mock(() =>
+		Promise.resolve(new Response("", { status: 200 })),
+	) as unknown as typeof fetch;
+});
+
+function mockFetch(responses: Record<string, unknown>[]) {
+	fetchCalls = [];
+	let callIndex = 0;
+	globalThis.fetch = mock(async (url: string, init?: RequestInit) => {
+		const body = init?.body ? JSON.parse(init.body as string) : {};
+		fetchCalls.push({ url: String(url), body });
+		const resp = responses[callIndex] ?? responses[responses.length - 1];
+		callIndex++;
+		return new Response(JSON.stringify(resp), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	}) as unknown as typeof fetch;
+}
+
+function mockFetchStatus(status: number) {
+	globalThis.fetch = mock(() =>
+		Promise.resolve(new Response("", { status })),
+	) as unknown as typeof fetch;
+}
+
+// ---------------------------------------------------------------------------
+// fetchTasks tests
+// ---------------------------------------------------------------------------
+
+test("fetchTasks returns [] when github_project_number not configured", async () => {
+	setToken("ghp_token");
+	const source = new GitHubProjectsSource();
+	const tasks = await source.fetchTasks({ repo: "testowner/testrepo" });
+	expect(tasks).toEqual([]);
+});
+
+test("fetchTasks returns [] when no token stored", async () => {
+	const source = new GitHubProjectsSource();
+	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
+	expect(tasks).toEqual([]);
+});
+
+test("fetchTasks maps a single page of Issue nodes to Task[] correctly including grouping", async () => {
+	setToken("ghp_token");
+	mockFetch([
+		makePageResponse([
+			makeIssueNode({
+				id: "item_001",
+				number: 5,
+				title: "My Issue",
+				body: "Some description",
+				labels: ["bug", "priority"],
+				milestone: { number: 2, title: "v1.0" },
+			}),
+		]),
+	]);
+
+	const source = new GitHubProjectsSource();
+	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
+
+	expect(tasks).toHaveLength(1);
+	expect(tasks[0]).toMatchObject({
+		id: "item_001",
+		title: "My Issue",
+		description: "Some description",
+		labels: ["bug", "priority"],
+		provider: "github_projects",
+		sourceIssueNumber: 5,
+		grouping: { id: "2", label: "v1.0" },
+	});
+});
+
+test("fetchTasks: issue with no milestone has no grouping field", async () => {
+	setToken("ghp_token");
+	mockFetch([makePageResponse([makeIssueNode({ id: "item_001" })])]);
+
+	const source = new GitHubProjectsSource();
+	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
+
+	expect(tasks).toHaveLength(1);
+	expect(tasks[0].grouping).toBeUndefined();
+});
+
+test("fetchTasks paginates correctly (two pages, both fetched and combined)", async () => {
+	setToken("ghp_token");
+	mockFetch([
+		makePageResponse(
+			[makeIssueNode({ id: "item_001", number: 1, title: "Issue 1" })],
+			true,
+			"cursor_page2",
+		),
+		makePageResponse([makeIssueNode({ id: "item_002", number: 2, title: "Issue 2" })]),
+	]);
+
+	const source = new GitHubProjectsSource();
+	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
+
+	expect(tasks).toHaveLength(2);
+	expect(fetchCalls).toHaveLength(2);
+	expect((fetchCalls[1].body.variables as { cursor: string }).cursor).toBe("cursor_page2");
+});
+
+test("fetchTasks filters out non-Issue content nodes", async () => {
+	setToken("ghp_token");
+	mockFetch([
+		makePageResponse([
+			makeIssueNode({ id: "item_001" }),
+			makeIssueNode({ id: "item_pr", contentType: "PullRequest" }),
+			makeIssueNode({ id: "item_draft", contentType: "DraftIssue" }),
+		]),
+	]);
+
+	const source = new GitHubProjectsSource();
+	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
+
+	expect(tasks).toHaveLength(1);
+	expect(tasks[0].id).toBe("item_001");
+});
+
+test("fetchTasks filters out closed issues", async () => {
+	setToken("ghp_token");
+	mockFetch([
+		makePageResponse([
+			makeIssueNode({ id: "item_open", state: "open" }),
+			makeIssueNode({ id: "item_closed", state: "closed" }),
+		]),
+	]);
+
+	const source = new GitHubProjectsSource();
+	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
+
+	expect(tasks).toHaveLength(1);
+	expect(tasks[0].id).toBe("item_open");
+});
+
+test("fetchTasks maps null body to empty string", async () => {
+	setToken("ghp_token");
+	mockFetch([makePageResponse([makeIssueNode({ body: null })])]);
+
+	const source = new GitHubProjectsSource();
+	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
+
+	expect(tasks[0].description).toBe("");
+});
+
+test("fetchTasks applies label filtering when repoSettings.labels is set", async () => {
+	setToken("ghp_token");
+	mockFetch([
+		makePageResponse([
+			makeIssueNode({ id: "item_bug", labels: ["bug"] }),
+			makeIssueNode({ id: "item_feat", labels: ["feature"] }),
+			makeIssueNode({ id: "item_both", labels: ["bug", "feature"] }),
+		]),
+	]);
+
+	const source = new GitHubProjectsSource();
+	const tasks = await source.fetchTasks({ ...BASE_REPO_SETTINGS, labels: ["bug"] });
+
+	expect(tasks).toHaveLength(2);
+	expect(tasks.map((t) => t.id).sort()).toEqual(["item_both", "item_bug"].sort());
+});
+
+test("fetchTasks throws GitHubAuthError on 401", async () => {
+	setToken("ghp_expired");
+	mockFetchStatus(401);
+
+	const source = new GitHubProjectsSource();
+	await expect(source.fetchTasks(BASE_REPO_SETTINGS)).rejects.toBeInstanceOf(GitHubAuthError);
+});
+
+test("fetchTasks throws readable error on GraphQL project-not-found", async () => {
+	setToken("ghp_token");
+	mockFetch([{ data: { organization: null, user: null } }]);
+
+	const source = new GitHubProjectsSource();
+	await expect(source.fetchTasks(BASE_REPO_SETTINGS)).rejects.toThrow(
+		/project.*not found/i,
+	);
+});
+
+test("fetchTasks wraps network errors as GitHubNetworkError", async () => {
+	setToken("ghp_token");
+	globalThis.fetch = mock(() =>
+		Promise.reject(new Error("Network failure")),
+	) as unknown as typeof fetch;
+
+	const source = new GitHubProjectsSource();
+	await expect(source.fetchTasks(BASE_REPO_SETTINGS)).rejects.toBeInstanceOf(
+		GitHubNetworkError,
+	);
+});
+
+// ---------------------------------------------------------------------------
+// transitionTask tests
+// ---------------------------------------------------------------------------
+
+async function setupSourceWithTasks(): Promise<InstanceType<typeof GitHubProjectsSource>> {
+	setToken("ghp_token");
+	mockFetch([makePageResponse([makeIssueNode()])]);
+	const source = new GitHubProjectsSource();
+	await source.fetchTasks(BASE_REPO_SETTINGS);
+	return source;
+}
+
+test("transitionTask calls correct GraphQL mutation", async () => {
+	const source = await setupSourceWithTasks();
+
+	mockFetch([
+		makeStatusFieldResponse([
+			{ id: "opt_todo", name: "Todo" },
+			{ id: "opt_done", name: "Done" },
+		]),
+		makeTransitionMutationResponse(),
+	]);
+
+	await source.transitionTask("item_001", "Done");
+
+	expect(fetchCalls).toHaveLength(2);
+	const mutationBody = fetchCalls[1].body;
+	expect(mutationBody.variables).toMatchObject({
+		projectId: "project_id_001",
+		itemId: "item_001",
+		fieldId: "field_status_001",
+		optionId: "opt_done",
+	});
+});
+
+test("transitionTask caches status field (only one field-lookup query on second call)", async () => {
+	const source = await setupSourceWithTasks();
+
+	mockFetch([
+		makeStatusFieldResponse([{ id: "opt_done", name: "Done" }]),
+		makeTransitionMutationResponse(),
+		makeTransitionMutationResponse(),
+	]);
+
+	await source.transitionTask("item_001", "Done");
+	await source.transitionTask("item_002", "Done");
+
+	// 2 total fetches: 1 field lookup + 2 mutations = 3 total, but 1 field lookup + 1 mutation for first call,
+	// then just 1 mutation for second call = 3 total
+	expect(fetchCalls).toHaveLength(3);
+	// First call: field lookup (index 0) + mutation (index 1)
+	// Second call: mutation only (index 2)
+	expect(fetchCalls[0].body.query).toContain("Status");
+	expect(fetchCalls[2].body.query).toContain("updateProjectV2ItemFieldValue");
+});
+
+test("transitionTask throws descriptively if no Status field", async () => {
+	const source = await setupSourceWithTasks();
+
+	mockFetch([
+		{
+			data: {
+				organization: { projectV2: { id: "project_id_001", field: null } },
+				user: null,
+			},
+		},
+	]);
+
+	await expect(source.transitionTask("item_001", "Done")).rejects.toThrow(/Status/);
+});
+
+// ---------------------------------------------------------------------------
+// fetchGitHubIssue tests
+// ---------------------------------------------------------------------------
+
+function makeRestIssueResponse(overrides: {
+	id?: number;
+	number?: number;
+	title?: string;
+	body?: string | null;
+	htmlUrl?: string;
+	labels?: string[];
+	milestone?: { number: number; title: string } | null;
+} = {}): Record<string, unknown> {
+	const {
+		id = 123456,
+		number = 7,
+		title = "REST issue",
+		body = "Issue via REST",
+		htmlUrl = "https://github.com/testowner/testrepo/issues/7",
+		labels = [],
+		milestone = null,
+	} = overrides;
+
+	return {
+		id,
+		number,
+		title,
+		body,
+		html_url: htmlUrl,
+		labels: labels.map((name) => ({ name })),
+		milestone,
+	};
+}
+
+test("fetchGitHubIssue maps a single issue correctly including grouping", async () => {
+	mockFetch([
+		makeRestIssueResponse({
+			id: 99,
+			number: 7,
+			title: "REST Issue Title",
+			body: "REST body",
+			labels: ["good first issue"],
+			milestone: { number: 3, title: "Sprint 1" },
+		}),
+	]);
+
+	const task = await fetchGitHubIssue("testowner", "testrepo", 7, "ghp_token");
+
+	expect(task).toMatchObject({
+		id: "99",
+		title: "REST Issue Title",
+		description: "REST body",
+		labels: ["good first issue"],
+		provider: "github_issue",
+		sourceIssueNumber: 7,
+		grouping: { id: "3", label: "Sprint 1" },
+	});
+});
+
+test("fetchGitHubIssue: issue with no milestone has no grouping field", async () => {
+	mockFetch([makeRestIssueResponse({ milestone: null })]);
+
+	const task = await fetchGitHubIssue("testowner", "testrepo", 7, "ghp_token");
+
+	expect(task.grouping).toBeUndefined();
+});
+
+test("fetchGitHubIssue maps null body to empty string", async () => {
+	mockFetch([makeRestIssueResponse({ body: null })]);
+
+	const task = await fetchGitHubIssue("testowner", "testrepo", 7, "ghp_token");
+
+	expect(task.description).toBe("");
+});
+
+test("fetchGitHubIssue throws on 404", async () => {
+	globalThis.fetch = mock(() =>
+		Promise.resolve(new Response("", { status: 404 })),
+	) as unknown as typeof fetch;
+
+	await expect(fetchGitHubIssue("testowner", "testrepo", 999, "ghp_token")).rejects.toThrow(
+		/not found/i,
+	);
+});
+
+test("fetchGitHubIssue throws GitHubAuthError on 401", async () => {
+	mockFetchStatus(401);
+
+	await expect(
+		fetchGitHubIssue("testowner", "testrepo", 7, "ghp_token"),
+	).rejects.toBeInstanceOf(GitHubAuthError);
+});
+
+test("fetchGitHubIssue wraps network errors as GitHubNetworkError", async () => {
+	globalThis.fetch = mock(() =>
+		Promise.reject(new Error("Connection refused")),
+	) as unknown as typeof fetch;
+
+	await expect(
+		fetchGitHubIssue("testowner", "testrepo", 7, "ghp_token"),
+	).rejects.toBeInstanceOf(GitHubNetworkError);
+});

--- a/src/services/__tests__/github-projects.test.ts
+++ b/src/services/__tests__/github-projects.test.ts
@@ -1,31 +1,21 @@
 import { beforeEach, expect, mock, test } from "bun:test";
-
-// ---------------------------------------------------------------------------
-// Mock @/services/github-auth before importing module under test.
-// Mocking the direct dependency (rather than the Tauri plugin two hops away)
-// avoids module-cache cross-contamination when the full test suite runs.
-// ---------------------------------------------------------------------------
-
-let _mockToken: string | null = null;
-
-mock.module("@/services/github-auth", () => ({
-	getGitHubToken: () => Promise.resolve(_mockToken),
-}));
-
-// ---------------------------------------------------------------------------
-// Import modules under test after mocks are registered
-// ---------------------------------------------------------------------------
-
-const {
+import {
 	GitHubProjectsSource,
 	GitHubAuthError,
 	GitHubNetworkError,
 	fetchGitHubIssue,
-} = await import("../github-projects");
+} from "../github-projects";
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Token control — injected into GitHubProjectsSource via constructor.
+// No mock.module needed; avoids module-cache cross-contamination in CI.
 // ---------------------------------------------------------------------------
+
+let _mockToken: string | null = null;
+
+function getToken(): Promise<string | null> {
+	return Promise.resolve(_mockToken);
+}
 
 function setToken(token: string | null) {
 	_mockToken = token;
@@ -170,13 +160,13 @@ function mockFetchStatus(status: number) {
 
 test("fetchTasks returns [] when github_project_number not configured", async () => {
 	setToken("ghp_token");
-	const source = new GitHubProjectsSource();
+	const source = new GitHubProjectsSource(getToken);
 	const tasks = await source.fetchTasks({ repo: "testowner/testrepo" });
 	expect(tasks).toEqual([]);
 });
 
 test("fetchTasks returns [] when no token stored", async () => {
-	const source = new GitHubProjectsSource();
+	const source = new GitHubProjectsSource(getToken);
 	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
 	expect(tasks).toEqual([]);
 });
@@ -196,7 +186,7 @@ test("fetchTasks maps a single page of Issue nodes to Task[] correctly including
 		]),
 	]);
 
-	const source = new GitHubProjectsSource();
+	const source = new GitHubProjectsSource(getToken);
 	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
 
 	expect(tasks).toHaveLength(1);
@@ -215,7 +205,7 @@ test("fetchTasks: issue with no milestone has no grouping field", async () => {
 	setToken("ghp_token");
 	mockFetch([makePageResponse([makeIssueNode({ id: "item_001" })])]);
 
-	const source = new GitHubProjectsSource();
+	const source = new GitHubProjectsSource(getToken);
 	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
 
 	expect(tasks).toHaveLength(1);
@@ -233,7 +223,7 @@ test("fetchTasks paginates correctly (two pages, both fetched and combined)", as
 		makePageResponse([makeIssueNode({ id: "item_002", number: 2, title: "Issue 2" })]),
 	]);
 
-	const source = new GitHubProjectsSource();
+	const source = new GitHubProjectsSource(getToken);
 	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
 
 	expect(tasks).toHaveLength(2);
@@ -251,7 +241,7 @@ test("fetchTasks filters out non-Issue content nodes", async () => {
 		]),
 	]);
 
-	const source = new GitHubProjectsSource();
+	const source = new GitHubProjectsSource(getToken);
 	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
 
 	expect(tasks).toHaveLength(1);
@@ -267,7 +257,7 @@ test("fetchTasks filters out closed issues", async () => {
 		]),
 	]);
 
-	const source = new GitHubProjectsSource();
+	const source = new GitHubProjectsSource(getToken);
 	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
 
 	expect(tasks).toHaveLength(1);
@@ -278,7 +268,7 @@ test("fetchTasks maps null body to empty string", async () => {
 	setToken("ghp_token");
 	mockFetch([makePageResponse([makeIssueNode({ body: null })])]);
 
-	const source = new GitHubProjectsSource();
+	const source = new GitHubProjectsSource(getToken);
 	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
 
 	expect(tasks[0].description).toBe("");
@@ -294,7 +284,7 @@ test("fetchTasks applies label filtering when repoSettings.labels is set", async
 		]),
 	]);
 
-	const source = new GitHubProjectsSource();
+	const source = new GitHubProjectsSource(getToken);
 	const tasks = await source.fetchTasks({ ...BASE_REPO_SETTINGS, labels: ["bug"] });
 
 	expect(tasks).toHaveLength(2);
@@ -305,7 +295,7 @@ test("fetchTasks throws GitHubAuthError on 401", async () => {
 	setToken("ghp_expired");
 	mockFetchStatus(401);
 
-	const source = new GitHubProjectsSource();
+	const source = new GitHubProjectsSource(getToken);
 	await expect(source.fetchTasks(BASE_REPO_SETTINGS)).rejects.toBeInstanceOf(GitHubAuthError);
 });
 
@@ -313,7 +303,7 @@ test("fetchTasks throws readable error on GraphQL project-not-found", async () =
 	setToken("ghp_token");
 	mockFetch([{ data: { organization: null, user: null } }]);
 
-	const source = new GitHubProjectsSource();
+	const source = new GitHubProjectsSource(getToken);
 	await expect(source.fetchTasks(BASE_REPO_SETTINGS)).rejects.toThrow(
 		/project.*not found/i,
 	);
@@ -325,7 +315,7 @@ test("fetchTasks wraps network errors as GitHubNetworkError", async () => {
 		Promise.reject(new Error("Network failure")),
 	) as unknown as typeof fetch;
 
-	const source = new GitHubProjectsSource();
+	const source = new GitHubProjectsSource(getToken);
 	await expect(source.fetchTasks(BASE_REPO_SETTINGS)).rejects.toBeInstanceOf(
 		GitHubNetworkError,
 	);
@@ -338,7 +328,7 @@ test("fetchTasks wraps network errors as GitHubNetworkError", async () => {
 async function setupSourceWithTasks(): Promise<InstanceType<typeof GitHubProjectsSource>> {
 	setToken("ghp_token");
 	mockFetch([makePageResponse([makeIssueNode()])]);
-	const source = new GitHubProjectsSource();
+	const source = new GitHubProjectsSource(getToken);
 	await source.fetchTasks(BASE_REPO_SETTINGS);
 	return source;
 }

--- a/src/services/__tests__/github-projects.test.ts
+++ b/src/services/__tests__/github-projects.test.ts
@@ -75,17 +75,17 @@ function makePageResponse(
 	hasNextPage = false,
 	endCursor = "cursor_end",
 ): Record<string, unknown> {
-	const projectData = {
-		id: "project_id_001",
-		items: {
-			pageInfo: { hasNextPage, endCursor },
-			nodes,
-		},
-	};
 	return {
 		data: {
-			organization: { projectV2: projectData },
-			user: null,
+			repositoryOwner: {
+				projectV2: {
+					id: "project_id_001",
+					items: {
+						pageInfo: { hasNextPage, endCursor },
+						nodes,
+					},
+				},
+			},
 		},
 	};
 }
@@ -95,7 +95,7 @@ function makeStatusFieldResponse(
 ): Record<string, unknown> {
 	return {
 		data: {
-			organization: {
+			repositoryOwner: {
 				projectV2: {
 					id: "project_id_001",
 					field: {
@@ -104,7 +104,6 @@ function makeStatusFieldResponse(
 					},
 				},
 			},
-			user: null,
 		},
 	};
 }
@@ -301,7 +300,7 @@ test("fetchTasks throws GitHubAuthError on 401", async () => {
 
 test("fetchTasks throws readable error on GraphQL project-not-found", async () => {
 	setToken("ghp_token");
-	mockFetch([{ data: { organization: null, user: null } }]);
+	mockFetch([{ data: { repositoryOwner: null } }]);
 
 	const source = new GitHubProjectsSource(getToken);
 	await expect(source.fetchTasks(BASE_REPO_SETTINGS)).rejects.toThrow(
@@ -383,8 +382,7 @@ test("transitionTask throws descriptively if no Status field", async () => {
 	mockFetch([
 		{
 			data: {
-				organization: { projectV2: { id: "project_id_001", field: null } },
-				user: null,
+				repositoryOwner: { projectV2: { id: "project_id_001", field: null } },
 			},
 		},
 	]);

--- a/src/services/github-auth.ts
+++ b/src/services/github-auth.ts
@@ -1,0 +1,31 @@
+import { LazyStore } from "@tauri-apps/plugin-store";
+
+const TOKEN_KEY = "github_token";
+
+const store = new LazyStore("github-auth.json", { defaults: {}, autoSave: true });
+
+export async function getGitHubToken(): Promise<string | null> {
+	try {
+		const value = await store.get<string>(TOKEN_KEY);
+		return typeof value === "string" ? value : null;
+	} catch {
+		throw new Error("Failed to read GitHub token from store");
+	}
+}
+
+export async function setGitHubToken(token: string): Promise<void> {
+	try {
+		await store.set(TOKEN_KEY, token);
+	} catch {
+		throw new Error("Failed to save GitHub token to store");
+	}
+}
+
+export async function hasGitHubToken(): Promise<boolean> {
+	try {
+		const value = await store.get<string>(TOKEN_KEY);
+		return typeof value === "string" && value.length > 0;
+	} catch {
+		throw new Error("Failed to check GitHub token in store");
+	}
+}

--- a/src/services/github-projects.ts
+++ b/src/services/github-projects.ts
@@ -33,75 +33,45 @@ export class GitHubNetworkError extends Error {
 // ---------------------------------------------------------------------------
 
 const PROJECT_ITEMS_QUERY = `
-  query($owner: String!, $projectNumber: Int!, $cursor: String) {
-    repositoryOwner(login: $owner) {
-      ... on Organization {
-        projectV2(number: $projectNumber) {
-          id
-          items(first: 50, after: $cursor) {
-            pageInfo { hasNextPage endCursor }
-            nodes {
-              id
-              content {
-                __typename
-                ... on Issue {
-                  number title body url state
-                  labels(first: 20) { nodes { name } }
-                  milestone { number title }
-                }
-              }
-            }
-          }
-        }
-      }
-      ... on User {
-        projectV2(number: $projectNumber) {
-          id
-          items(first: 50, after: $cursor) {
-            pageInfo { hasNextPage endCursor }
-            nodes {
-              id
-              content {
-                __typename
-                ... on Issue {
-                  number title body url state
-                  labels(first: 20) { nodes { name } }
-                  milestone { number title }
-                }
-              }
-            }
+  fragment ProjectItems on ProjectV2 {
+    id
+    items(first: 50, after: $cursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id
+        content {
+          __typename
+          ... on Issue {
+            number title body url state
+            labels(first: 20) { nodes { name } }
+            milestone { number title }
           }
         }
       }
     }
   }
+  query($owner: String!, $projectNumber: Int!, $cursor: String) {
+    repositoryOwner(login: $owner) {
+      ... on Organization { projectV2(number: $projectNumber) { ...ProjectItems } }
+      ... on User         { projectV2(number: $projectNumber) { ...ProjectItems } }
+    }
+  }
 `;
 
 const STATUS_FIELD_QUERY = `
+  fragment ProjectStatusField on ProjectV2 {
+    id
+    field(name: "Status") {
+      ... on ProjectV2SingleSelectField {
+        id
+        options { id name }
+      }
+    }
+  }
   query($owner: String!, $projectNumber: Int!) {
     repositoryOwner(login: $owner) {
-      ... on Organization {
-        projectV2(number: $projectNumber) {
-          id
-          field(name: "Status") {
-            ... on ProjectV2SingleSelectField {
-              id
-              options { id name }
-            }
-          }
-        }
-      }
-      ... on User {
-        projectV2(number: $projectNumber) {
-          id
-          field(name: "Status") {
-            ... on ProjectV2SingleSelectField {
-              id
-              options { id name }
-            }
-          }
-        }
-      }
+      ... on Organization { projectV2(number: $projectNumber) { ...ProjectStatusField } }
+      ... on User         { projectV2(number: $projectNumber) { ...ProjectStatusField } }
     }
   }
 `;

--- a/src/services/github-projects.ts
+++ b/src/services/github-projects.ts
@@ -206,11 +206,16 @@ export class GitHubProjectsSource implements TicketSource {
 		fieldId: string;
 		options: Map<string, string>;
 	} | null = null;
+	private readonly _getToken: () => Promise<string | null>;
+
+	constructor(getToken?: () => Promise<string | null>) {
+		this._getToken = getToken ?? getGitHubToken;
+	}
 
 	async fetchTasks(repoSettings: RepoSettings): Promise<Task[]> {
 		if (!repoSettings.github_project_number) return [];
 
-		const token = await getGitHubToken();
+		const token = await this._getToken();
 		if (!token) return [];
 
 		const [owner] = repoSettings.repo.split("/");
@@ -254,7 +259,7 @@ export class GitHubProjectsSource implements TicketSource {
 			throw new Error("fetchTasks must be called before transitionTask");
 		}
 
-		const token = await getGitHubToken();
+		const token = await this._getToken();
 		if (!token) throw new GitHubAuthError("No GitHub token configured");
 
 		if (!this._statusCache) {

--- a/src/services/github-projects.ts
+++ b/src/services/github-projects.ts
@@ -1,0 +1,360 @@
+import type { RepoSettings } from "@/types/config";
+import type { Task } from "@/types/task";
+import { getGitHubToken } from "@/services/github-auth";
+import type { TicketSource } from "@/services/ticket-source";
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export class GitHubAuthError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "GitHubAuthError";
+	}
+}
+
+export class GitHubNetworkError extends Error {
+	constructor(message: string, options?: ErrorOptions) {
+		super(message, options);
+		this.name = "GitHubNetworkError";
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GraphQL queries / mutations
+// ---------------------------------------------------------------------------
+
+const PROJECT_ITEMS_QUERY = `
+  query($owner: String!, $projectNumber: Int!, $cursor: String) {
+    organization(login: $owner) {
+      projectV2(number: $projectNumber) {
+        id
+        items(first: 50, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            content {
+              __typename
+              ... on Issue {
+                number title body url state
+                labels(first: 20) { nodes { name } }
+                milestone { number title }
+              }
+            }
+          }
+        }
+      }
+    }
+    user(login: $owner) {
+      projectV2(number: $projectNumber) {
+        id
+        items(first: 50, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            content {
+              __typename
+              ... on Issue {
+                number title body url state
+                labels(first: 20) { nodes { name } }
+                milestone { number title }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const STATUS_FIELD_QUERY = `
+  query($owner: String!, $projectNumber: Int!) {
+    organization(login: $owner) {
+      projectV2(number: $projectNumber) {
+        id
+        field(name: "Status") {
+          ... on ProjectV2SingleSelectField {
+            id
+            options { id name }
+          }
+        }
+      }
+    }
+    user(login: $owner) {
+      projectV2(number: $projectNumber) {
+        id
+        field(name: "Status") {
+          ... on ProjectV2SingleSelectField {
+            id
+            options { id name }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const TRANSITION_MUTATION = `
+  mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+    updateProjectV2ItemFieldValue(input: {
+      projectId: $projectId
+      itemId: $itemId
+      fieldId: $fieldId
+      value: { singleSelectOptionId: $optionId }
+    }) {
+      projectV2Item { id }
+    }
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function graphqlRequest(
+	token: string,
+	query: string,
+	variables: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	let response: Response;
+	try {
+		response = await fetch("https://api.github.com/graphql", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ query, variables }),
+		});
+	} catch (cause) {
+		throw new GitHubNetworkError("Failed to connect to GitHub API", { cause });
+	}
+
+	if (response.status === 401) {
+		throw new GitHubAuthError("GitHub token is invalid or expired");
+	}
+
+	return response.json() as Promise<Record<string, unknown>>;
+}
+
+function extractProject(
+	data: Record<string, unknown>,
+	owner: string,
+	projectNumber: number,
+): Record<string, unknown> {
+	const d = data.data as Record<string, unknown> | undefined;
+	const org = (d?.organization as Record<string, unknown> | null)?.projectV2 as
+		| Record<string, unknown>
+		| null
+		| undefined;
+	const usr = (d?.user as Record<string, unknown> | null)?.projectV2 as
+		| Record<string, unknown>
+		| null
+		| undefined;
+	const project = org ?? usr;
+	if (!project) {
+		throw new Error(`GitHub project #${projectNumber} not found for ${owner}`);
+	}
+	return project;
+}
+
+function mapIssueNode(node: Record<string, unknown>): Task | null {
+	const content = node.content as Record<string, unknown> | null | undefined;
+	if (!content?.url) return null;
+	if ((content.state as string | undefined) !== "open") return null;
+
+	const milestone = content.milestone as
+		| { number: number; title: string }
+		| null
+		| undefined;
+	const labelNodes = (
+		(content.labels as Record<string, unknown> | undefined)?.nodes as
+			| Array<{ name: string }>
+			| undefined
+	) ?? [];
+
+	const task: Task = {
+		id: node.id as string,
+		title: content.title as string,
+		description: (content.body as string | null) ?? "",
+		labels: labelNodes.map((l) => l.name),
+		url: content.url as string,
+		provider: "github_projects",
+		sourceIssueNumber: content.number as number,
+	};
+
+	if (milestone) {
+		task.grouping = {
+			id: String(milestone.number),
+			label: milestone.title,
+		};
+	}
+
+	return task;
+}
+
+// ---------------------------------------------------------------------------
+// GitHubProjectsSource
+// ---------------------------------------------------------------------------
+
+export class GitHubProjectsSource implements TicketSource {
+	private _owner: string | null = null;
+	private _projectNumber: number | null = null;
+	private _statusCache: {
+		projectId: string;
+		fieldId: string;
+		options: Map<string, string>;
+	} | null = null;
+
+	async fetchTasks(repoSettings: RepoSettings): Promise<Task[]> {
+		if (!repoSettings.github_project_number) return [];
+
+		const token = await getGitHubToken();
+		if (!token) return [];
+
+		const [owner] = repoSettings.repo.split("/");
+		this._owner = owner;
+		this._projectNumber = repoSettings.github_project_number;
+		this._statusCache = null;
+
+		const tasks: Task[] = [];
+		let cursor: string | null = null;
+
+		do {
+			const data = await graphqlRequest(token, PROJECT_ITEMS_QUERY, {
+				owner,
+				projectNumber: repoSettings.github_project_number,
+				cursor,
+			});
+
+			const project = extractProject(data, owner, repoSettings.github_project_number);
+			const items = project.items as Record<string, unknown>;
+			const pageInfo = items.pageInfo as { hasNextPage: boolean; endCursor: string };
+			const nodes = (items.nodes as Array<Record<string, unknown>>) ?? [];
+
+			for (const node of nodes) {
+				const task = mapIssueNode(node);
+				if (task) tasks.push(task);
+			}
+
+			cursor = pageInfo.hasNextPage ? pageInfo.endCursor : null;
+		} while (cursor !== null);
+
+		if (repoSettings.labels && repoSettings.labels.length > 0) {
+			const labelSet = new Set(repoSettings.labels);
+			return tasks.filter((t) => t.labels.some((l) => labelSet.has(l)));
+		}
+
+		return tasks;
+	}
+
+	async transitionTask(taskId: string, status: string): Promise<void> {
+		if (!this._owner || !this._projectNumber) {
+			throw new Error("fetchTasks must be called before transitionTask");
+		}
+
+		const token = await getGitHubToken();
+		if (!token) throw new GitHubAuthError("No GitHub token configured");
+
+		if (!this._statusCache) {
+			const data = await graphqlRequest(token, STATUS_FIELD_QUERY, {
+				owner: this._owner,
+				projectNumber: this._projectNumber,
+			});
+
+			const project = extractProject(data, this._owner, this._projectNumber);
+			const field = project.field as Record<string, unknown> | null | undefined;
+
+			if (!field?.id) {
+				throw new Error(`No "Status" field found on project #${this._projectNumber}`);
+			}
+
+			const options = new Map<string, string>();
+			for (const opt of (field.options as Array<{ id: string; name: string }>) ?? []) {
+				options.set(opt.name, opt.id);
+			}
+
+			this._statusCache = {
+				projectId: project.id as string,
+				fieldId: field.id as string,
+				options,
+			};
+		}
+
+		const optionId = this._statusCache.options.get(status);
+		if (!optionId) {
+			throw new Error(
+				`Status option "${status}" not found. Available: ${[...this._statusCache.options.keys()].join(", ")}`,
+			);
+		}
+
+		await graphqlRequest(token, TRANSITION_MUTATION, {
+			projectId: this._statusCache.projectId,
+			itemId: taskId,
+			fieldId: this._statusCache.fieldId,
+			optionId,
+		});
+	}
+}
+
+// ---------------------------------------------------------------------------
+// fetchGitHubIssue — standalone helper for single-issue URL import flow
+// ---------------------------------------------------------------------------
+
+export async function fetchGitHubIssue(
+	owner: string,
+	repo: string,
+	issueNumber: number,
+	token: string,
+): Promise<Task> {
+	let response: Response;
+	try {
+		response = await fetch(
+			`https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}`,
+			{
+				headers: {
+					Authorization: `Bearer ${token}`,
+					Accept: "application/vnd.github+json",
+				},
+			},
+		);
+	} catch (cause) {
+		throw new GitHubNetworkError("Failed to connect to GitHub API", { cause });
+	}
+
+	if (response.status === 401) {
+		throw new GitHubAuthError("GitHub token is invalid or expired");
+	}
+
+	if (response.status === 404) {
+		throw new Error(`Issue #${issueNumber} not found in ${owner}/${repo}`);
+	}
+
+	const issue = (await response.json()) as Record<string, unknown>;
+
+	const milestone = issue.milestone as
+		| { number: number; title: string }
+		| null
+		| undefined;
+	const labelNodes = (issue.labels as Array<{ name: string }> | undefined) ?? [];
+
+	const task: Task = {
+		id: String(issue.id),
+		title: issue.title as string,
+		description: (issue.body as string | null) ?? "",
+		labels: labelNodes.map((l) => l.name),
+		url: issue.html_url as string,
+		provider: "github_issue",
+		sourceIssueNumber: issueNumber,
+	};
+
+	if (milestone) {
+		task.grouping = {
+			id: String(milestone.number),
+			label: milestone.title,
+		};
+	}
+
+	return task;
+}

--- a/src/services/github-projects.ts
+++ b/src/services/github-projects.ts
@@ -1,7 +1,14 @@
 import type { RepoSettings } from "@/types/config";
 import type { Task } from "@/types/task";
-import { getGitHubToken } from "@/services/github-auth";
 import type { TicketSource } from "@/services/ticket-source";
+
+// Lazy import so loading this module does not pull in github-auth (and its
+// LazyStore singleton) until the first real token lookup. Tests always inject
+// a getToken function so this path is never exercised in the test suite.
+async function defaultGetToken(): Promise<string | null> {
+	const { getGitHubToken } = await import("@/services/github-auth");
+	return getGitHubToken();
+}
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -208,8 +215,8 @@ export class GitHubProjectsSource implements TicketSource {
 	} | null = null;
 	private readonly _getToken: () => Promise<string | null>;
 
-	constructor(getToken?: () => Promise<string | null>) {
-		this._getToken = getToken ?? getGitHubToken;
+	constructor(getToken: () => Promise<string | null> = defaultGetToken) {
+		this._getToken = getToken;
 	}
 
 	async fetchTasks(repoSettings: RepoSettings): Promise<Task[]> {

--- a/src/services/github-projects.ts
+++ b/src/services/github-projects.ts
@@ -34,38 +34,40 @@ export class GitHubNetworkError extends Error {
 
 const PROJECT_ITEMS_QUERY = `
   query($owner: String!, $projectNumber: Int!, $cursor: String) {
-    organization(login: $owner) {
-      projectV2(number: $projectNumber) {
-        id
-        items(first: 50, after: $cursor) {
-          pageInfo { hasNextPage endCursor }
-          nodes {
-            id
-            content {
-              __typename
-              ... on Issue {
-                number title body url state
-                labels(first: 20) { nodes { name } }
-                milestone { number title }
+    repositoryOwner(login: $owner) {
+      ... on Organization {
+        projectV2(number: $projectNumber) {
+          id
+          items(first: 50, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              content {
+                __typename
+                ... on Issue {
+                  number title body url state
+                  labels(first: 20) { nodes { name } }
+                  milestone { number title }
+                }
               }
             }
           }
         }
       }
-    }
-    user(login: $owner) {
-      projectV2(number: $projectNumber) {
-        id
-        items(first: 50, after: $cursor) {
-          pageInfo { hasNextPage endCursor }
-          nodes {
-            id
-            content {
-              __typename
-              ... on Issue {
-                number title body url state
-                labels(first: 20) { nodes { name } }
-                milestone { number title }
+      ... on User {
+        projectV2(number: $projectNumber) {
+          id
+          items(first: 50, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              content {
+                __typename
+                ... on Issue {
+                  number title body url state
+                  labels(first: 20) { nodes { name } }
+                  milestone { number title }
+                }
               }
             }
           }
@@ -77,24 +79,26 @@ const PROJECT_ITEMS_QUERY = `
 
 const STATUS_FIELD_QUERY = `
   query($owner: String!, $projectNumber: Int!) {
-    organization(login: $owner) {
-      projectV2(number: $projectNumber) {
-        id
-        field(name: "Status") {
-          ... on ProjectV2SingleSelectField {
-            id
-            options { id name }
+    repositoryOwner(login: $owner) {
+      ... on Organization {
+        projectV2(number: $projectNumber) {
+          id
+          field(name: "Status") {
+            ... on ProjectV2SingleSelectField {
+              id
+              options { id name }
+            }
           }
         }
       }
-    }
-    user(login: $owner) {
-      projectV2(number: $projectNumber) {
-        id
-        field(name: "Status") {
-          ... on ProjectV2SingleSelectField {
-            id
-            options { id name }
+      ... on User {
+        projectV2(number: $projectNumber) {
+          id
+          field(name: "Status") {
+            ... on ProjectV2SingleSelectField {
+              id
+              options { id name }
+            }
           }
         }
       }
@@ -151,15 +155,8 @@ function extractProject(
 	projectNumber: number,
 ): Record<string, unknown> {
 	const d = data.data as Record<string, unknown> | undefined;
-	const org = (d?.organization as Record<string, unknown> | null)?.projectV2 as
-		| Record<string, unknown>
-		| null
-		| undefined;
-	const usr = (d?.user as Record<string, unknown> | null)?.projectV2 as
-		| Record<string, unknown>
-		| null
-		| undefined;
-	const project = org ?? usr;
+	const repoOwner = d?.repositoryOwner as Record<string, unknown> | null | undefined;
+	const project = (repoOwner?.projectV2 as Record<string, unknown> | null | undefined) ?? null;
 	if (!project) {
 		throw new Error(`GitHub project #${projectNumber} not found for ${owner}`);
 	}

--- a/src/services/ticket-source.ts
+++ b/src/services/ticket-source.ts
@@ -1,0 +1,7 @@
+import type { RepoSettings } from "@/types/config";
+import type { Task } from "@/types/task";
+
+export interface TicketSource {
+	fetchTasks(repoSettings: RepoSettings): Promise<Task[]>;
+	transitionTask(taskId: string, status: string): Promise<void>;
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -32,6 +32,9 @@ export const RepoSettingsSchema = z.object({
 	repo: z.string().regex(/^[^/]+\/[^/]+$/, "Must be in 'owner/repo' format"),
 	ai_backend: z.enum(AI_BACKENDS).optional(),
 	editor: z.enum(EDITORS).optional(),
+	github_project_number: z.number().int().positive().optional(),
+	labels: z.array(z.string()).optional(),
+	auto_grab: z.boolean().optional(),
 });
 
 export type RepoSettings = z.infer<typeof RepoSettingsSchema>;

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,0 +1,13 @@
+export interface Task {
+	id: string;
+	title: string;
+	description: string;
+	labels: string[];
+	grouping?: {
+		id: string;
+		label: string;
+	};
+	url: string;
+	provider: string;
+	sourceIssueNumber?: number;
+}


### PR DESCRIPTION
## Summary

- Adds `Task` interface and `TicketSource` interface as provider-agnostic abstractions
- Extends `RepoSettings` schema with `github_project_number`, `labels`, and `auto_grab` fields
- `github-auth` service: persists GitHub PAT in `plugin-store` (`LazyStore`) with no token leakage in error messages
- `GitHubProjectsSource`: paginated GraphQL fetch (50 items/page), org→user fallback, open-issues-only filter, label filtering, milestone→grouping mapping, lazy status-field caching for transitions
- `fetchGitHubIssue`: standalone REST helper for single-issue URL import flow

## Test plan

- [x] `bun test src/services/__tests__/github-auth.test.ts` — 5 tests (token round-trip, error safety)
- [x] `bun test src/services/__tests__/github-projects.test.ts` — 21 tests (pagination, filtering, label filter, auth errors, network errors, transition caching, REST helper)
- [x] `bun run test:services` — 111 tests across 10 files, 0 fail
- [x] `bunx tsc --noEmit` — no errors
- [x] `bun run lint` — no errors

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)