### PR TITLE
feat: agent execution in worktree (issue #11)

### DIFF
--- a/src/lib/agentTaskRepository.ts
+++ b/src/lib/agentTaskRepository.ts
@@ -18,6 +18,7 @@ interface AgentTaskRow {
 	owner: string;
 	repo: string;
 	branch_name: string;
+	base_branch: string;
 	worktree_path: string | null;
 	status: string;
 	plan: string | null;
@@ -44,6 +45,7 @@ function rowToTask(row: AgentTaskRow): AgentTask {
 		owner: row.owner,
 		repo: row.repo,
 		branchName: row.branch_name,
+		baseBranch: row.base_branch,
 		worktreePath: row.worktree_path ?? undefined,
 		status: row.status as TaskStatus,
 		plan: row.plan ? (JSON.parse(row.plan) as string[]) : undefined,
@@ -72,13 +74,13 @@ export async function createAgentTask(input: CreateAgentTaskInput): Promise<void
 		`INSERT INTO agent_tasks (
 			id, task_type, parent_task_id, title, description,
 			source_url, source_provider, workspace_path, repo_path,
-			owner, repo, branch_name, worktree_path, status,
+			owner, repo, branch_name, base_branch, worktree_path, status,
 			plan, acp_session_id,
 			pr_url, head_sha, error, archived_at, created_at, updated_at
 		) VALUES (
 			?, ?, ?, ?, ?,
 			?, ?, ?, ?,
-			?, ?, ?, ?, ?,
+			?, ?, ?, ?, ?, ?,
 			?, ?,
 			?, ?, ?, ?, ?, ?
 		)`,
@@ -95,6 +97,7 @@ export async function createAgentTask(input: CreateAgentTaskInput): Promise<void
 			input.owner,
 			input.repo,
 			input.branchName,
+			input.baseBranch,
 			input.worktreePath ?? null,
 			input.status,
 			input.plan ? JSON.stringify(input.plan) : null,
@@ -149,6 +152,7 @@ export async function updateAgentTask(
 			owner            = COALESCE(?, owner),
 			repo             = COALESCE(?, repo),
 			branch_name      = COALESCE(?, branch_name),
+			base_branch      = COALESCE(?, base_branch),
 			worktree_path    = COALESCE(?, worktree_path),
 			status           = COALESCE(?, status),
 			plan             = COALESCE(?, plan),
@@ -169,6 +173,7 @@ export async function updateAgentTask(
 			updates.owner ?? null,
 			updates.repo ?? null,
 			updates.branchName ?? null,
+			updates.baseBranch ?? null,
 			updates.worktreePath ?? null,
 			updates.status ?? null,
 			updates.plan !== undefined ? JSON.stringify(updates.plan) : null,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -79,6 +79,13 @@ const MIGRATIONS: Array<(db: Database) => Promise<void>> = [
 		);
 		await db.execute("CREATE INDEX idx_agent_tasks_status ON agent_tasks(status)");
 	},
+
+	// v3 — base branch per task (issue #11)
+	async (db) => {
+		await db.execute(
+			"ALTER TABLE agent_tasks ADD COLUMN base_branch TEXT NOT NULL DEFAULT 'main'"
+		);
+	},
 ];
 
 async function migrate(db: Database): Promise<void> {

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -184,6 +184,9 @@ export async function getResolvedConfig(
 			if (repoSettings.editor !== undefined) {
 				resolved.editor = repoSettings.editor;
 			}
+			if (repoSettings.default_branch !== undefined) {
+				resolved.default_branch = repoSettings.default_branch;
+			}
 		}
 	}
 

--- a/src/services/executor.ts
+++ b/src/services/executor.ts
@@ -1,0 +1,92 @@
+import { getAgentDefinition } from "@/lib/agents";
+import { getAgentTask, updateAgentTask } from "@/lib/agentTaskRepository";
+import { acpCreateSession, acpLoadSession } from "@/services/acpService";
+import { getResolvedConfig } from "@/services/configService";
+import { getDiffStat, getCommitMessages } from "@/services/git";
+import { emitSystemLog } from "@/services/logStreamService";
+import type { PlannerLogCallback } from "@/services/planner";
+
+const EXECUTION_PROMPT = `The plan has been approved. Please implement it now in the working directory.
+
+Run the project's tests before considering the task done.
+Commit in logical chunks. Do not push — the orchestrator handles that.`;
+
+export async function executeTask(taskId: string, onLine?: PlannerLogCallback): Promise<void> {
+	const task = await getAgentTask(taskId);
+	if (!task) throw new Error(`Task ${taskId} not found`);
+	if (!task.worktreePath) throw new Error(`Task ${taskId} has no worktree path`);
+
+	const { worktreePath } = task;
+
+	await updateAgentTask(taskId, { status: "executing" });
+
+	const emit: PlannerLogCallback = (event) => {
+		onLine?.(event);
+	};
+
+	try {
+		const settings = await getResolvedConfig(task.workspacePath, task.owner, task.repo);
+		const agentDef = getAgentDefinition(settings.ai_backend);
+
+		// Resume the planning session if available; otherwise create a fresh one
+		const session = task.acpSessionId
+			? await acpLoadSession(task.acpSessionId, worktreePath, agentDef.acpCommand, agentDef.acpArgs)
+			: await acpCreateSession(worktreePath, agentDef.acpCommand, agentDef.acpArgs);
+
+		if (!task.acpSessionId) {
+			await updateAgentTask(taskId, { acpSessionId: session.sessionId });
+		}
+
+		// Stream execution output line by line
+		let lineBuffer = "";
+		const unsubscribe = session.subscribe((agentEvent) => {
+			if (agentEvent.event.type !== "message_chunk") return;
+			const text = agentEvent.event.text;
+			lineBuffer += text;
+			const lines = lineBuffer.split("\n");
+			lineBuffer = lines.pop() ?? "";
+			for (const line of lines) {
+				emitSystemLog(taskId, line, emit).catch(console.error);
+			}
+		});
+
+		await session.send(EXECUTION_PROMPT);
+		unsubscribe();
+		await session.dispose();
+
+		// Flush any remaining partial line
+		if (lineBuffer) {
+			await emitSystemLog(taskId, lineBuffer, emit);
+		}
+
+		// Capture and log diff stat + commit messages
+		const baseBranch = `origin/${task.baseBranch}`;
+		const [diffStat, commitMessages] = await Promise.all([
+			getDiffStat(worktreePath, baseBranch),
+			getCommitMessages(worktreePath, baseBranch),
+		]);
+
+		await emitSystemLog(
+			taskId,
+			`Changes: ${diffStat.filesChanged} files, +${diffStat.insertions}/-${diffStat.deletions}`,
+			emit
+		);
+		if (commitMessages.length > 0) {
+			await emitSystemLog(taskId, `Commits:\n${commitMessages.map((m) => `  ${m}`).join("\n")}`, emit);
+		}
+
+		await updateAgentTask(taskId, { status: "pushing" });
+	} catch (err) {
+		await updateAgentTask(taskId, {
+			status: "failed",
+			error: err instanceof Error ? err.message : String(err),
+		});
+		// Worktree is preserved intentionally for debugging
+		throw err;
+	}
+}
+
+export async function retryTask(taskId: string, onLine?: PlannerLogCallback): Promise<void> {
+	await updateAgentTask(taskId, { status: "executing", error: undefined });
+	await executeTask(taskId, onLine);
+}

--- a/src/services/git.ts
+++ b/src/services/git.ts
@@ -44,6 +44,21 @@ export function worktreePath(
 }
 
 /**
+ * Detect the default branch of a remote by reading the symbolic ref.
+ * Falls back to "main" if the ref isn't set or the command fails.
+ */
+export async function detectDefaultBranch(repoPath: string): Promise<string> {
+	const cmd = Command.create("git", ["symbolic-ref", "refs/remotes/origin/HEAD"], {
+		cwd: repoPath,
+	});
+	const output = await cmd.execute();
+	if (output.code === 0 && output.stdout.trim()) {
+		return output.stdout.trim().split("/").pop() ?? "main";
+	}
+	return "main";
+}
+
+/**
  * Create a new worktree branched off baseBranch
  */
 export async function createWorktree(opts: {

--- a/src/services/planner.ts
+++ b/src/services/planner.ts
@@ -3,9 +3,10 @@ import { getAgentDefinition } from "@/lib/agents";
 import { createAgentTask, getAgentTask, updateAgentTask } from "@/lib/agentTaskRepository";
 import { acpCreateSession } from "@/services/acpService";
 import { getResolvedConfig } from "@/services/configService";
-import { agentBranchName, createWorktree, worktreePath as buildWorktreePath } from "@/services/git";
+import { agentBranchName, createWorktree, detectDefaultBranch, worktreePath as buildWorktreePath } from "@/services/git";
 import { emitSystemLog } from "@/services/logStreamService";
 import { buildSystemPrompt, detectLanguage } from "@/services/workspace";
+import { executeTask } from "@/services/executor";
 import type { TaskType } from "@/types/agent-task";
 import type { Task } from "@/types/task";
 import type { ProcessEvent } from "@/types/logs";
@@ -44,6 +45,7 @@ export async function startTask(
 		owner: workspaceCtx.owner,
 		repo: workspaceCtx.repo,
 		branchName,
+		baseBranch: "main",
 		worktreePath: wPath,
 		status: "pending",
 	});
@@ -80,18 +82,24 @@ export async function generatePlan(
 	};
 
 	try {
+		// Resolve base branch: per-repo config → git detection → "main"
+		const settings = await getResolvedConfig(task.workspacePath, task.owner, task.repo);
+		const baseBranch =
+			settings.default_branch ?? (await detectDefaultBranch(task.repoPath));
+
+		await updateAgentTask(taskId, { baseBranch });
+
 		// Create the worktree
 		await createWorktree({
 			repoPath: task.repoPath,
 			worktreePath,
 			branchName: task.branchName,
-			baseBranch: "main",
+			baseBranch,
 			taskId,
 			onLine: emit,
 		});
 
 		// Build workspace context for the system prompt
-		const settings = await getResolvedConfig(task.workspacePath, task.owner, task.repo);
 		const primaryLanguage = await detectLanguage(task.repoPath);
 
 		const workspaceCtx: WorkspaceContext = {
@@ -197,9 +205,12 @@ export async function approvePlan(taskId: string): Promise<void> {
 	const task = await getAgentTask(taskId);
 	if (!task) throw new Error(`Task ${taskId} not found`);
 
-	await updateAgentTask(taskId, { status: "executing" });
-
-	// TODO: issue #11 — trigger execution here using task.acpSessionId
+	executeTask(taskId).catch(async (err) => {
+		await updateAgentTask(taskId, {
+			status: "failed",
+			error: err instanceof Error ? err.message : String(err),
+		}).catch(console.error);
+	});
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types/agent-task.ts
+++ b/src/types/agent-task.ts
@@ -24,6 +24,7 @@ export interface AgentTask {
 	owner: string;
 	repo: string;
 	branchName: string;
+	baseBranch: string;
 	worktreePath?: string;
 	status: TaskStatus;
 	plan?: string[];

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -34,6 +34,7 @@ export const RepoSettingsSchema = z.object({
 	repo: z.string().regex(/^[^/]+\/[^/]+$/, "Must be in 'owner/repo' format"),
 	ai_backend: z.enum(AI_BACKENDS).optional(),
 	editor: z.enum(EDITORS).optional(),
+	default_branch: z.string().optional(),
 	github_project_number: z.number().int().positive().optional(),
 	labels: z.array(z.string()).optional(),
 	auto_grab: z.boolean().optional(),
@@ -50,6 +51,7 @@ export type ResolvedConfig = {
 	ai_backend: AIBackend;
 	editor?: Editor;
 	plan_review: boolean;
+	default_branch?: string;
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Dynamic base branch resolution**: `detectDefaultBranch()` reads `refs/remotes/origin/HEAD` via git and falls back to `"main"`; per-repo `default_branch` config override also supported
- **DB migration v3**: adds `base_branch TEXT NOT NULL DEFAULT 'main'` column to `agent_tasks` so retry and push steps always use the same branch the task was created from
- **Executor service** (`src/services/executor.ts`): `executeTask` resumes the existing ACP session from `acpSessionId` (falls back to a fresh session if missing), sends the execution prompt as a follow-up, streams output to the log viewer, captures diff stat + commit messages, then transitions to `pushing`; `retryTask` resets status and delegates
- **`approvePlan` wired up**: replaces the `// TODO: issue #11` stub with an async fire-and-forget call to `executeTask`, mirroring the `generatePlan` pattern

## Test plan

- [ ] Start a task and approve the plan — status should transition `awaiting_review → executing → pushing`
- [ ] Confirm agent output streams to the log viewer during execution
- [ ] Kill the app mid-execution and retry — worktree should be preserved, retry should pick up with a new session
- [ ] Set `default_branch = "develop"` in a repo settings TOML — confirm that branch is used for the worktree base
- [ ] On a repo where `refs/remotes/origin/HEAD` is unset, confirm fallback to `"main"`
- [ ] Confirm a failed task preserves its worktree and transitions to `failed` status

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)