### PR TITLE
Introduce projects table to normalize per-repo data

### DIFF
--- a/src/lib/agentTaskRepository.ts
+++ b/src/lib/agentTaskRepository.ts
@@ -2,21 +2,18 @@ import { getDb } from "@/lib/db";
 import type { AgentTask, TaskStatus, TaskType } from "@/types/agent-task";
 
 // ---------------------------------------------------------------------------
-// Row shape returned by SQLite selects
+// Row shape returned by SQLite selects (agent_tasks JOIN projects)
 // ---------------------------------------------------------------------------
 
 interface AgentTaskRow {
 	id: string;
+	project_id: string;
 	task_type: string;
 	parent_task_id: string | null;
 	title: string;
 	description: string;
 	source_url: string | null;
 	source_provider: string | null;
-	workspace_path: string;
-	repo_path: string;
-	owner: string;
-	repo: string;
 	branch_name: string;
 	worktree_path: string | null;
 	status: string;
@@ -28,11 +25,30 @@ interface AgentTaskRow {
 	archived_at: string | null;
 	created_at: string;
 	updated_at: string;
+	// From projects JOIN
+	workspace_path: string;
+	owner: string;
+	repo: string;
+	repo_path: string;
+	base_branch: string;
 }
+
+const TASK_JOIN = `
+	SELECT
+		t.id, t.project_id, t.task_type, t.parent_task_id,
+		t.title, t.description, t.source_url, t.source_provider,
+		t.branch_name, t.worktree_path, t.status, t.plan,
+		t.acp_session_id, t.pr_url, t.head_sha, t.error,
+		t.archived_at, t.created_at, t.updated_at,
+		p.workspace_path, p.owner, p.repo, p.repo_path, p.base_branch
+	FROM agent_tasks t
+	JOIN projects p ON p.id = t.project_id
+`;
 
 function rowToTask(row: AgentTaskRow): AgentTask {
 	return {
 		id: row.id,
+		projectId: row.project_id,
 		taskType: row.task_type as TaskType,
 		parentTaskId: row.parent_task_id ?? undefined,
 		title: row.title,
@@ -43,6 +59,7 @@ function rowToTask(row: AgentTaskRow): AgentTask {
 		repoPath: row.repo_path,
 		owner: row.owner,
 		repo: row.repo,
+		baseBranch: row.base_branch,
 		branchName: row.branch_name,
 		worktreePath: row.worktree_path ?? undefined,
 		status: row.status as TaskStatus,
@@ -61,39 +78,51 @@ function rowToTask(row: AgentTaskRow): AgentTask {
 // Public API
 // ---------------------------------------------------------------------------
 
-export type CreateAgentTaskInput = Omit<AgentTask, "createdAt" | "updatedAt">;
+export interface CreateAgentTaskInput {
+	id: string;
+	projectId: string;
+	taskType: TaskType;
+	parentTaskId?: string;
+	title: string;
+	description: string;
+	sourceUrl?: string;
+	sourceProvider?: string;
+	branchName: string;
+	worktreePath?: string;
+	status: TaskStatus;
+	plan?: string[];
+	acpSessionId?: string;
+	prUrl?: string;
+	headSha?: string;
+	error?: string;
+	archivedAt?: string;
+}
 
 export async function createAgentTask(input: CreateAgentTaskInput): Promise<void> {
 	const db = await getDb();
 	const now = new Date().toISOString();
-	const { id } = input;
 
 	await db.execute(
 		`INSERT INTO agent_tasks (
-			id, task_type, parent_task_id, title, description,
-			source_url, source_provider, workspace_path, repo_path,
-			owner, repo, branch_name, worktree_path, status,
-			plan, acp_session_id,
-			pr_url, head_sha, error, archived_at, created_at, updated_at
+			id, project_id, task_type, parent_task_id, title, description,
+			source_url, source_provider, branch_name, worktree_path, status,
+			plan, acp_session_id, pr_url, head_sha, error, archived_at,
+			created_at, updated_at
 		) VALUES (
+			?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?,
-			?, ?, ?, ?,
-			?, ?, ?, ?, ?,
-			?, ?,
-			?, ?, ?, ?, ?, ?
+			?, ?, ?, ?, ?, ?,
+			?, ?
 		)`,
 		[
-			id,
+			input.id,
+			input.projectId,
 			input.taskType,
 			input.parentTaskId ?? null,
 			input.title,
 			input.description,
 			input.sourceUrl ?? null,
 			input.sourceProvider ?? null,
-			input.workspacePath,
-			input.repoPath,
-			input.owner,
-			input.repo,
 			input.branchName,
 			input.worktreePath ?? null,
 			input.status,
@@ -107,20 +136,32 @@ export async function createAgentTask(input: CreateAgentTaskInput): Promise<void
 			now,
 		]
 	);
-
 }
 
 export async function getAgentTask(id: string): Promise<AgentTask | null> {
 	const db = await getDb();
 	const rows = await db.select<AgentTaskRow[]>(
-		"SELECT * FROM agent_tasks WHERE id = ?",
+		`${TASK_JOIN} WHERE t.id = ?`,
 		[id]
 	);
 	return rows[0] ? rowToTask(rows[0]) : null;
 }
 
 export type UpdateAgentTaskInput = Partial<
-	Omit<AgentTask, "id" | "taskType" | "parentTaskId" | "createdAt" | "updatedAt">
+	Omit<
+		AgentTask,
+		| "id"
+		| "projectId"
+		| "taskType"
+		| "parentTaskId"
+		| "workspacePath"
+		| "repoPath"
+		| "owner"
+		| "repo"
+		| "baseBranch"
+		| "createdAt"
+		| "updatedAt"
+	>
 >;
 
 export async function updateAgentTask(
@@ -140,34 +181,26 @@ export async function updateAgentTask(
 
 	await db.execute(
 		`UPDATE agent_tasks SET
-			title            = COALESCE(?, title),
-			description      = COALESCE(?, description),
-			source_url       = COALESCE(?, source_url),
-			source_provider  = COALESCE(?, source_provider),
-			workspace_path   = COALESCE(?, workspace_path),
-			repo_path        = COALESCE(?, repo_path),
-			owner            = COALESCE(?, owner),
-			repo             = COALESCE(?, repo),
-			branch_name      = COALESCE(?, branch_name),
-			worktree_path    = COALESCE(?, worktree_path),
-			status           = COALESCE(?, status),
-			plan             = COALESCE(?, plan),
-			acp_session_id   = COALESCE(?, acp_session_id),
-			pr_url           = COALESCE(?, pr_url),
-			head_sha         = COALESCE(?, head_sha),
-			error            = COALESCE(?, error),
-			archived_at      = COALESCE(?, archived_at),
-			updated_at       = ?
+			title          = COALESCE(?, title),
+			description    = COALESCE(?, description),
+			source_url     = COALESCE(?, source_url),
+			source_provider = COALESCE(?, source_provider),
+			branch_name    = COALESCE(?, branch_name),
+			worktree_path  = COALESCE(?, worktree_path),
+			status         = COALESCE(?, status),
+			plan           = COALESCE(?, plan),
+			acp_session_id = COALESCE(?, acp_session_id),
+			pr_url         = COALESCE(?, pr_url),
+			head_sha       = COALESCE(?, head_sha),
+			error          = COALESCE(?, error),
+			archived_at    = COALESCE(?, archived_at),
+			updated_at     = ?
 		WHERE id = ?`,
 		[
 			updates.title ?? null,
 			updates.description ?? null,
 			updates.sourceUrl ?? null,
 			updates.sourceProvider ?? null,
-			updates.workspacePath ?? null,
-			updates.repoPath ?? null,
-			updates.owner ?? null,
-			updates.repo ?? null,
 			updates.branchName ?? null,
 			updates.worktreePath ?? null,
 			updates.status ?? null,
@@ -190,9 +223,9 @@ export async function listActiveAgentTasks(
 ): Promise<AgentTask[]> {
 	const db = await getDb();
 	const rows = await db.select<AgentTaskRow[]>(
-		`SELECT * FROM agent_tasks
-		 WHERE workspace_path = ? AND owner = ? AND repo = ? AND archived_at IS NULL
-		 ORDER BY created_at DESC`,
+		`${TASK_JOIN}
+		 WHERE p.workspace_path = ? AND p.owner = ? AND p.repo = ? AND t.archived_at IS NULL
+		 ORDER BY t.created_at DESC`,
 		[workspacePath, owner, repo]
 	);
 	return rows.map(rowToTask);
@@ -205,9 +238,9 @@ export async function listArchivedAgentTasks(
 ): Promise<AgentTask[]> {
 	const db = await getDb();
 	const rows = await db.select<AgentTaskRow[]>(
-		`SELECT * FROM agent_tasks
-		 WHERE workspace_path = ? AND owner = ? AND repo = ? AND archived_at IS NOT NULL
-		 ORDER BY archived_at DESC`,
+		`${TASK_JOIN}
+		 WHERE p.workspace_path = ? AND p.owner = ? AND p.repo = ? AND t.archived_at IS NOT NULL
+		 ORDER BY t.archived_at DESC`,
 		[workspacePath, owner, repo]
 	);
 	return rows.map(rowToTask);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -79,6 +79,97 @@ const MIGRATIONS: Array<(db: Database) => Promise<void>> = [
 		);
 		await db.execute("CREATE INDEX idx_agent_tasks_status ON agent_tasks(status)");
 	},
+
+	// v3 — introduce projects table, normalize per-repo data (issue #48)
+	async (db) => {
+		// Create projects table
+		await db.execute(`
+			CREATE TABLE projects (
+				id             TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL,
+				owner          TEXT NOT NULL,
+				repo           TEXT NOT NULL,
+				repo_path      TEXT NOT NULL,
+				base_branch    TEXT NOT NULL DEFAULT 'main',
+				created_at     TEXT NOT NULL,
+				updated_at     TEXT NOT NULL
+			)
+		`);
+		await db.execute(
+			"CREATE UNIQUE INDEX idx_projects_workspace_owner_repo ON projects(workspace_path, owner, repo)"
+		);
+
+		// Migrate one project row per unique (workspace_path, owner, repo)
+		const now = new Date().toISOString();
+		await db.execute(`
+			INSERT INTO projects (id, workspace_path, owner, repo, repo_path, base_branch, created_at, updated_at)
+			SELECT lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),
+			       workspace_path, owner, repo, repo_path, 'main', '${now}', '${now}'
+			FROM (
+				SELECT DISTINCT workspace_path, owner, repo, repo_path
+				FROM agent_tasks
+			)
+		`);
+
+		// Recreate agent_tasks without the per-repo columns, adding project_id FK
+		await db.execute(`
+			CREATE TABLE agent_tasks_new (
+				id               TEXT PRIMARY KEY,
+				project_id       TEXT NOT NULL REFERENCES projects(id),
+				task_type        TEXT NOT NULL DEFAULT 'ticket_impl',
+				parent_task_id   TEXT REFERENCES agent_tasks_new(id),
+				title            TEXT NOT NULL,
+				description      TEXT NOT NULL,
+				source_url       TEXT,
+				source_provider  TEXT,
+				branch_name      TEXT NOT NULL,
+				worktree_path    TEXT,
+				status           TEXT NOT NULL DEFAULT 'pending',
+				plan             TEXT,
+				acp_session_id   TEXT,
+				pr_url           TEXT,
+				head_sha         TEXT,
+				error            TEXT,
+				archived_at      TEXT,
+				created_at       TEXT NOT NULL,
+				updated_at       TEXT NOT NULL
+			)
+		`);
+
+		// Copy rows, resolving project_id via subquery
+		await db.execute(`
+			INSERT INTO agent_tasks_new
+			SELECT
+				t.id,
+				p.id,
+				t.task_type,
+				t.parent_task_id,
+				t.title,
+				t.description,
+				t.source_url,
+				t.source_provider,
+				t.branch_name,
+				t.worktree_path,
+				t.status,
+				t.plan,
+				t.acp_session_id,
+				t.pr_url,
+				t.head_sha,
+				t.error,
+				t.archived_at,
+				t.created_at,
+				t.updated_at
+			FROM agent_tasks t
+			JOIN projects p ON p.workspace_path = t.workspace_path
+			                AND p.owner = t.owner
+			                AND p.repo = t.repo
+		`);
+
+		await db.execute("DROP TABLE agent_tasks");
+		await db.execute("ALTER TABLE agent_tasks_new RENAME TO agent_tasks");
+		await db.execute("CREATE INDEX idx_agent_tasks_project ON agent_tasks(project_id)");
+		await db.execute("CREATE INDEX idx_agent_tasks_status ON agent_tasks(status)");
+	},
 ];
 
 async function migrate(db: Database): Promise<void> {

--- a/src/lib/projectRepository.ts
+++ b/src/lib/projectRepository.ts
@@ -1,0 +1,69 @@
+import { v4 as uuid } from "uuid";
+import { getDb } from "@/lib/db";
+import { detectDefaultBranch } from "@/services/git";
+import type { Project } from "@/types/project";
+
+interface ProjectRow {
+	id: string;
+	workspace_path: string;
+	owner: string;
+	repo: string;
+	repo_path: string;
+	base_branch: string;
+	created_at: string;
+	updated_at: string;
+}
+
+function rowToProject(row: ProjectRow): Project {
+	return {
+		id: row.id,
+		workspacePath: row.workspace_path,
+		owner: row.owner,
+		repo: row.repo,
+		repoPath: row.repo_path,
+		baseBranch: row.base_branch,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+export async function findOrCreateProject(
+	workspacePath: string,
+	owner: string,
+	repo: string,
+	repoPath: string
+): Promise<Project> {
+	const db = await getDb();
+	const existing = await db.select<ProjectRow[]>(
+		"SELECT * FROM projects WHERE workspace_path = ? AND owner = ? AND repo = ?",
+		[workspacePath, owner, repo]
+	);
+	if (existing[0]) return rowToProject(existing[0]);
+
+	const id = uuid();
+	const now = new Date().toISOString();
+	const baseBranch = await detectDefaultBranch(repoPath);
+
+	await db.execute(
+		`INSERT INTO projects (id, workspace_path, owner, repo, repo_path, base_branch, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		[id, workspacePath, owner, repo, repoPath, baseBranch, now, now]
+	);
+
+	return { id, workspacePath, owner, repo, repoPath, baseBranch, createdAt: now, updatedAt: now };
+}
+
+export async function getProject(id: string): Promise<Project | null> {
+	const db = await getDb();
+	const rows = await db.select<ProjectRow[]>("SELECT * FROM projects WHERE id = ?", [id]);
+	return rows[0] ? rowToProject(rows[0]) : null;
+}
+
+export async function listProjects(workspacePath: string): Promise<Project[]> {
+	const db = await getDb();
+	const rows = await db.select<ProjectRow[]>(
+		"SELECT * FROM projects WHERE workspace_path = ? ORDER BY created_at ASC",
+		[workspacePath]
+	);
+	return rows.map(rowToProject);
+}

--- a/src/services/git.ts
+++ b/src/services/git.ts
@@ -209,6 +209,27 @@ export function parseDiffStat(output: string): DiffStat {
 }
 
 /**
+ * Detect the default remote branch (e.g. "main" or "master").
+ * Uses `git symbolic-ref refs/remotes/origin/HEAD --short` and strips the
+ * "origin/" prefix. Falls back to "main" if the ref is unset or the command
+ * fails (shallow clone, no remote fetch yet, etc.).
+ */
+export async function detectDefaultBranch(repoPath: string): Promise<string> {
+	const cmd = Command.create(
+		"git",
+		["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+		{ cwd: repoPath }
+	);
+	const output = await cmd.execute();
+	if (output.code === 0) {
+		const ref = output.stdout.trim();
+		const slash = ref.lastIndexOf("/");
+		return slash >= 0 ? ref.slice(slash + 1) : ref || "main";
+	}
+	return "main";
+}
+
+/**
  * Get commit messages since branching from baseBranch
  * Non-streaming operation
  */

--- a/src/services/planner.ts
+++ b/src/services/planner.ts
@@ -1,6 +1,7 @@
 import { v4 as uuid } from "uuid";
 import { getAgentDefinition } from "@/lib/agents";
 import { createAgentTask, getAgentTask, updateAgentTask } from "@/lib/agentTaskRepository";
+import { findOrCreateProject } from "@/lib/projectRepository";
 import { acpCreateSession } from "@/services/acpService";
 import { getResolvedConfig } from "@/services/configService";
 import { agentBranchName, createWorktree, worktreePath as buildWorktreePath } from "@/services/git";
@@ -31,18 +32,22 @@ export async function startTask(
 		id
 	);
 
+	const project = await findOrCreateProject(
+		workspaceCtx.workspacePath,
+		workspaceCtx.owner,
+		workspaceCtx.repo,
+		workspaceCtx.repoPath
+	);
+
 	await createAgentTask({
 		id,
+		projectId: project.id,
 		taskType: opts?.taskType ?? "ticket_impl",
 		parentTaskId: opts?.parentTaskId,
 		title: task.title,
 		description: task.description,
 		sourceUrl: task.url,
 		sourceProvider: task.provider,
-		workspacePath: workspaceCtx.workspacePath,
-		repoPath: workspaceCtx.repoPath,
-		owner: workspaceCtx.owner,
-		repo: workspaceCtx.repo,
 		branchName,
 		worktreePath: wPath,
 		status: "pending",
@@ -85,7 +90,7 @@ export async function generatePlan(
 			repoPath: task.repoPath,
 			worktreePath,
 			branchName: task.branchName,
-			baseBranch: "main",
+			baseBranch: task.baseBranch,
 			taskId,
 			onLine: emit,
 		});

--- a/src/types/agent-task.ts
+++ b/src/types/agent-task.ts
@@ -13,16 +13,19 @@ export type TaskType = "ticket_impl" | "pr_revision" | "manual";
 
 export interface AgentTask {
 	id: string;
+	projectId: string;
 	taskType: TaskType;
 	parentTaskId?: string;
 	title: string;
 	description: string;
 	sourceUrl?: string;
 	sourceProvider?: string;
+	// Denormalized from projects JOIN — read-only on the task
 	workspacePath: string;
 	repoPath: string;
 	owner: string;
 	repo: string;
+	baseBranch: string;
 	branchName: string;
 	worktreePath?: string;
 	status: TaskStatus;

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,10 @@
+export interface Project {
+	id: string;
+	workspacePath: string;
+	owner: string;
+	repo: string;
+	repoPath: string;
+	baseBranch: string;
+	createdAt: string;
+	updatedAt: string;
+}


### PR DESCRIPTION
Closes #48

## Summary

- Adds a `projects` table with a unique constraint on `(workspace_path, owner, repo)`, removing the five duplicated columns (`workspace_path`, `owner`, `repo`, `repo_path`, plus the new `base_branch`) from `agent_tasks`
- Adds `detectDefaultBranch` to the git service — runs `git symbolic-ref refs/remotes/origin/HEAD --short` on project creation; falls back to `"main"`
- Adds `src/lib/projectRepository.ts` with `findOrCreateProject` (idempotent), `getProject`, and `listProjects`
- All task queries JOIN `projects` so the full flat `AgentTask` object (including `workspacePath`, `owner`, `repo`, `repoPath`, `baseBranch`) is still returned to callers without an extra round-trip
- `startTask` calls `findOrCreateProject` before inserting the task row
- `generatePlan` uses `task.baseBranch` instead of the previously hardcoded `"main"`
- Migration v3 handles table recreation and data backfill for existing rows (SQLite DROP COLUMN workaround)

## Test plan

- [x] `bun run build` — clean, no type errors
- [x] `bun run test:services` — 111 tests pass
- [x] `bun run lint` — no issues
- [ ] Manual: create a task, verify project row is created with correct `base_branch`
- [ ] Manual: create a second task for the same repo, verify the same project row is reused

🤖 Generated with [Claude Code](https://claude.com/claude-code)