### PR TITLE
Add PR service and ticket transition support

### DIFF
--- a/src/lib/agentTaskRepository.ts
+++ b/src/lib/agentTaskRepository.ts
@@ -14,6 +14,7 @@ interface AgentTaskRow {
 	description: string;
 	source_url: string | null;
 	source_provider: string | null;
+	source_item_id: string | null;
 	branch_name: string;
 	worktree_path: string | null;
 	status: string;
@@ -36,7 +37,7 @@ interface AgentTaskRow {
 const TASK_JOIN = `
 	SELECT
 		t.id, t.project_id, t.task_type, t.parent_task_id,
-		t.title, t.description, t.source_url, t.source_provider,
+		t.title, t.description, t.source_url, t.source_provider, t.source_item_id,
 		t.branch_name, t.worktree_path, t.status, t.plan,
 		t.acp_session_id, t.pr_url, t.head_sha, t.error,
 		t.archived_at, t.created_at, t.updated_at,
@@ -55,6 +56,7 @@ function rowToTask(row: AgentTaskRow): AgentTask {
 		description: row.description,
 		sourceUrl: row.source_url ?? undefined,
 		sourceProvider: row.source_provider ?? undefined,
+		sourceItemId: row.source_item_id ?? undefined,
 		workspacePath: row.workspace_path,
 		repoPath: row.repo_path,
 		owner: row.owner,
@@ -87,6 +89,7 @@ export interface CreateAgentTaskInput {
 	description: string;
 	sourceUrl?: string;
 	sourceProvider?: string;
+	sourceItemId?: string;
 	branchName: string;
 	worktreePath?: string;
 	status: TaskStatus;
@@ -105,14 +108,14 @@ export async function createAgentTask(input: CreateAgentTaskInput): Promise<void
 	await db.execute(
 		`INSERT INTO agent_tasks (
 			id, project_id, task_type, parent_task_id, title, description,
-			source_url, source_provider, branch_name, worktree_path, status,
+			source_url, source_provider, source_item_id, branch_name, worktree_path, status,
 			plan, acp_session_id, pr_url, head_sha, error, archived_at,
 			created_at, updated_at
 		) VALUES (
 			?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?,
-			?, ?
+			?, ?, ?
 		)`,
 		[
 			input.id,
@@ -123,6 +126,7 @@ export async function createAgentTask(input: CreateAgentTaskInput): Promise<void
 			input.description,
 			input.sourceUrl ?? null,
 			input.sourceProvider ?? null,
+			input.sourceItemId ?? null,
 			input.branchName,
 			input.worktreePath ?? null,
 			input.status,
@@ -185,6 +189,7 @@ export async function updateAgentTask(
 			description    = COALESCE(?, description),
 			source_url     = COALESCE(?, source_url),
 			source_provider = COALESCE(?, source_provider),
+			source_item_id = COALESCE(?, source_item_id),
 			branch_name    = COALESCE(?, branch_name),
 			worktree_path  = COALESCE(?, worktree_path),
 			status         = COALESCE(?, status),
@@ -201,6 +206,7 @@ export async function updateAgentTask(
 			updates.description ?? null,
 			updates.sourceUrl ?? null,
 			updates.sourceProvider ?? null,
+			updates.sourceItemId ?? null,
 			updates.branchName ?? null,
 			updates.worktreePath ?? null,
 			updates.status ?? null,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -170,6 +170,11 @@ const MIGRATIONS: Array<(db: Database) => Promise<void>> = [
 		await db.execute("CREATE INDEX idx_agent_tasks_project ON agent_tasks(project_id)");
 		await db.execute("CREATE INDEX idx_agent_tasks_status ON agent_tasks(status)");
 	},
+
+	// v4 — add source_item_id to agent_tasks for ticket source transitions (issue #12)
+	async (db) => {
+		await db.execute("ALTER TABLE agent_tasks ADD COLUMN source_item_id TEXT");
+	},
 ];
 
 async function migrate(db: Database): Promise<void> {

--- a/src/services/__tests__/github-projects.test.ts
+++ b/src/services/__tests__/github-projects.test.ts
@@ -157,15 +157,8 @@ function mockFetchStatus(status: number) {
 // fetchTasks tests
 // ---------------------------------------------------------------------------
 
-test("fetchTasks returns [] when github_project_number not configured", async () => {
-	setToken("ghp_token");
-	const source = new GitHubProjectsSource(getToken);
-	const tasks = await source.fetchTasks({ repo: "testowner/testrepo" });
-	expect(tasks).toEqual([]);
-});
-
 test("fetchTasks returns [] when no token stored", async () => {
-	const source = new GitHubProjectsSource(getToken);
+	const source = new GitHubProjectsSource("testowner", 42, getToken);
 	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
 	expect(tasks).toEqual([]);
 });
@@ -185,7 +178,7 @@ test("fetchTasks maps a single page of Issue nodes to Task[] correctly including
 		]),
 	]);
 
-	const source = new GitHubProjectsSource(getToken);
+	const source = new GitHubProjectsSource("testowner", 42, getToken);
 	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
 
 	expect(tasks).toHaveLength(1);
@@ -204,7 +197,7 @@ test("fetchTasks: issue with no milestone has no grouping field", async () => {
 	setToken("ghp_token");
 	mockFetch([makePageResponse([makeIssueNode({ id: "item_001" })])]);
 
-	const source = new GitHubProjectsSource(getToken);
+	const source = new GitHubProjectsSource("testowner", 42, getToken);
 	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
 
 	expect(tasks).toHaveLength(1);
@@ -222,7 +215,7 @@ test("fetchTasks paginates correctly (two pages, both fetched and combined)", as
 		makePageResponse([makeIssueNode({ id: "item_002", number: 2, title: "Issue 2" })]),
 	]);
 
-	const source = new GitHubProjectsSource(getToken);
+	const source = new GitHubProjectsSource("testowner", 42, getToken);
 	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
 
 	expect(tasks).toHaveLength(2);
@@ -240,7 +233,7 @@ test("fetchTasks filters out non-Issue content nodes", async () => {
 		]),
 	]);
 
-	const source = new GitHubProjectsSource(getToken);
+	const source = new GitHubProjectsSource("testowner", 42, getToken);
 	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
 
 	expect(tasks).toHaveLength(1);
@@ -256,7 +249,7 @@ test("fetchTasks filters out closed issues", async () => {
 		]),
 	]);
 
-	const source = new GitHubProjectsSource(getToken);
+	const source = new GitHubProjectsSource("testowner", 42, getToken);
 	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
 
 	expect(tasks).toHaveLength(1);
@@ -267,7 +260,7 @@ test("fetchTasks maps null body to empty string", async () => {
 	setToken("ghp_token");
 	mockFetch([makePageResponse([makeIssueNode({ body: null })])]);
 
-	const source = new GitHubProjectsSource(getToken);
+	const source = new GitHubProjectsSource("testowner", 42, getToken);
 	const tasks = await source.fetchTasks(BASE_REPO_SETTINGS);
 
 	expect(tasks[0].description).toBe("");
@@ -283,7 +276,7 @@ test("fetchTasks applies label filtering when repoSettings.labels is set", async
 		]),
 	]);
 
-	const source = new GitHubProjectsSource(getToken);
+	const source = new GitHubProjectsSource("testowner", 42, getToken);
 	const tasks = await source.fetchTasks({ ...BASE_REPO_SETTINGS, labels: ["bug"] });
 
 	expect(tasks).toHaveLength(2);
@@ -294,7 +287,7 @@ test("fetchTasks throws GitHubAuthError on 401", async () => {
 	setToken("ghp_expired");
 	mockFetchStatus(401);
 
-	const source = new GitHubProjectsSource(getToken);
+	const source = new GitHubProjectsSource("testowner", 42, getToken);
 	await expect(source.fetchTasks(BASE_REPO_SETTINGS)).rejects.toBeInstanceOf(GitHubAuthError);
 });
 
@@ -302,7 +295,7 @@ test("fetchTasks throws readable error on GraphQL project-not-found", async () =
 	setToken("ghp_token");
 	mockFetch([{ data: { repositoryOwner: null } }]);
 
-	const source = new GitHubProjectsSource(getToken);
+	const source = new GitHubProjectsSource("testowner", 42, getToken);
 	await expect(source.fetchTasks(BASE_REPO_SETTINGS)).rejects.toThrow(
 		/project.*not found/i,
 	);
@@ -314,7 +307,7 @@ test("fetchTasks wraps network errors as GitHubNetworkError", async () => {
 		Promise.reject(new Error("Network failure")),
 	) as unknown as typeof fetch;
 
-	const source = new GitHubProjectsSource(getToken);
+	const source = new GitHubProjectsSource("testowner", 42, getToken);
 	await expect(source.fetchTasks(BASE_REPO_SETTINGS)).rejects.toBeInstanceOf(
 		GitHubNetworkError,
 	);
@@ -327,7 +320,7 @@ test("fetchTasks wraps network errors as GitHubNetworkError", async () => {
 async function setupSourceWithTasks(): Promise<InstanceType<typeof GitHubProjectsSource>> {
 	setToken("ghp_token");
 	mockFetch([makePageResponse([makeIssueNode()])]);
-	const source = new GitHubProjectsSource(getToken);
+	const source = new GitHubProjectsSource("testowner", 42, getToken);
 	await source.fetchTasks(BASE_REPO_SETTINGS);
 	return source;
 }

--- a/src/services/__tests__/pr-service.test.ts
+++ b/src/services/__tests__/pr-service.test.ts
@@ -1,0 +1,484 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock ONLY leaf-level external modules, never sibling services that have
+// their own test files. See executor.test.ts for the full rationale.
+//
+// Has own test file → mock its leaf deps:
+//   git.ts           → @tauri-apps/plugin-shell
+//   configService.ts → @/lib/fs
+//   logStreamService → @/lib/db
+//   github-auth.ts   → @tauri-apps/plugin-store
+//   github-projects  → global.fetch + @tauri-apps/plugin-store (token path)
+//
+// No own test file → mock directly:
+//   @/lib/agentTaskRepository, @/services/acpService, @/lib/agents
+// ---------------------------------------------------------------------------
+
+// --- @/lib/db — covers logStreamService internally ---
+const mockDbExecute = mock(async () => {});
+mock.module("@/lib/db", () => ({
+	getDb: mock(() =>
+		Promise.resolve({
+			execute: mockDbExecute,
+			select: mock(async () => []),
+		})
+	),
+}));
+
+// --- @/lib/agentTaskRepository (no separate test file) ---
+const mockGetAgentTask = mock(async (_id: string) => null as unknown);
+const mockUpdateAgentTask = mock(async (_id: string, _updates: unknown) => {});
+mock.module("@/lib/agentTaskRepository", () => ({
+	getAgentTask: mockGetAgentTask,
+	updateAgentTask: mockUpdateAgentTask,
+}));
+
+// --- @/services/acpService (no separate test file) ---
+const makeSessionHandle = (sessionId = "sess-1", descriptionText = "## Summary\n- Test PR") => ({
+	sessionId,
+	send: mock(async () => {}),
+	subscribe: mock((handler: (event: unknown) => void) => {
+		handler({ event: { type: "message_chunk", text: descriptionText } });
+		return () => {};
+	}),
+	dispose: mock(async () => {}),
+	cancel: mock(async () => {}),
+	setPermissionMode: mock(async () => {}),
+	resolvePermission: mock(() => {}),
+	currentModelId: "",
+	currentModeId: "",
+	availableModels: [],
+	availableModes: [],
+});
+
+const mockAcpLoadSession = mock(async () => makeSessionHandle("sess-1"));
+const mockAcpCreateSession = mock(async () => makeSessionHandle("sess-new"));
+mock.module("@/services/acpService", () => ({
+	acpLoadSession: mockAcpLoadSession,
+	acpCreateSession: mockAcpCreateSession,
+}));
+
+// --- @/lib/agents (no separate test file) ---
+const mockGetAgentDefinition = mock(() => ({ acpCommand: "node", acpArgs: [] }));
+mock.module("@/lib/agents", () => ({
+	getAgentDefinition: mockGetAgentDefinition,
+}));
+
+// --- @/lib/fs — drives configService and readRepoSettings ---
+const mockExists = mock(async () => false);
+const mockReadTextFile = mock(async () => "");
+mock.module("@/lib/fs", () => ({
+	exists: mockExists,
+	readTextFile: mockReadTextFile,
+	writeTextFile: mock(async () => {}),
+	mkdir: mock(async () => {}),
+	readDir: mock(async () => []),
+	remove: mock(async () => {}),
+}));
+
+// --- @/services/github-auth — mocked directly to avoid LazyStore singleton issue.
+// github-auth.ts creates `const store = new LazyStore(...)` at module load time;
+// if github-auth.test.ts ran first, that singleton already exists and can't be
+// replaced via @tauri-apps/plugin-store. Direct mock is safe here because
+// pr-service.test.ts always runs after github-auth.test.ts (alphabetical order).
+const mockGetGitHubToken = mock(async () => "test-token" as string | null);
+mock.module("@/services/github-auth", () => ({
+	getGitHubToken: mockGetGitHubToken,
+	setGitHubToken: mock(async () => {}),
+	hasGitHubToken: mock(async () => true),
+}));
+
+// --- @tauri-apps/plugin-shell — drives git.ts (pushBranch via runProcess,
+//     getDiffStat and getCommitMessages via execute) ---
+const spawnExitCodes: number[] = [];
+const executeResults: Array<{ code: number; stdout: string; stderr: string }> = [];
+
+const mockCreateCommand = mock(() => {
+	let onClose: ((data: { code: number }) => void) | null = null;
+	return {
+		execute: mock(async () => executeResults.shift() ?? { code: 0, stdout: "", stderr: "" }),
+		stdout: { on: mock() },
+		stderr: { on: mock() },
+		on: mock((event: string, handler: (data: unknown) => void) => {
+			if (event === "close") onClose = handler as (data: { code: number }) => void;
+		}),
+		spawn: mock(async () => {
+			const code = spawnExitCodes.shift() ?? 0;
+			onClose?.({ code });
+			return { write: mock(), kill: mock() };
+		}),
+	};
+});
+
+mock.module("@tauri-apps/plugin-shell", () => ({
+	Command: { create: mockCreateCommand },
+}));
+
+// ---------------------------------------------------------------------------
+// global.fetch mock — controls GitHub REST API calls
+// ---------------------------------------------------------------------------
+
+type FetchResponse = { ok: boolean; status: number; body: unknown };
+const fetchResponses: FetchResponse[] = [];
+
+const mockFetch = mock(async (_url: string, _init?: unknown) => {
+	const resp = fetchResponses.shift() ?? { ok: true, status: 200, body: {} };
+	return {
+		ok: resp.ok,
+		status: resp.status,
+		json: async () => resp.body,
+		text: async () => JSON.stringify(resp.body),
+	};
+});
+
+globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+// ---------------------------------------------------------------------------
+// Import after mocks are registered
+// ---------------------------------------------------------------------------
+
+const { openPullRequest, PushError } = await import("../pr-service");
+
+// ---------------------------------------------------------------------------
+// Shared fixture
+// ---------------------------------------------------------------------------
+
+const baseTask = {
+	id: "t1",
+	projectId: "proj-1",
+	taskType: "ticket_impl",
+	title: "Add feature X",
+	description: "Implement the X feature",
+	sourceUrl: "https://github.com/acme/app/issues/42",
+	sourceProvider: "github_projects",
+	sourceItemId: undefined as string | undefined,
+	workspacePath: "/ws",
+	repoPath: "/ws/_repositories/acme/app",
+	owner: "acme",
+	repo: "app",
+	baseBranch: "main",
+	branchName: "ai/t1",
+	worktreePath: "/ws/_worktrees/acme/app/t1",
+	status: "pushing",
+	acpSessionId: "sess-1",
+	createdAt: "2024-01-01T00:00:00Z",
+	updatedAt: "2024-01-01T00:00:00Z",
+};
+
+// Push default successful git responses: push (spawn exit 0), getDiffStat, getCommitMessages
+function pushSuccessGitResults() {
+	spawnExitCodes.push(0); // pushBranch
+	executeResults.push(
+		{ code: 0, stdout: "3 files changed, 20 insertions(+), 5 deletions(-)", stderr: "" },
+		{ code: 0, stdout: "feat: add feature X\nfix: edge case", stderr: "" },
+	);
+}
+
+// Push default successful GitHub API responses: PR creation (+ optional labels)
+function pushSuccessFetchResults(opts: { labels?: boolean } = {}) {
+	fetchResponses.push({
+		ok: true,
+		status: 201,
+		body: { number: 99, html_url: "https://github.com/acme/app/pull/99" },
+	});
+	if (opts.labels) {
+		fetchResponses.push({ ok: true, status: 200, body: [] });
+	}
+}
+
+beforeEach(() => {
+	mockDbExecute.mockClear();
+	mockGetAgentTask.mockClear();
+	mockUpdateAgentTask.mockClear();
+	mockAcpLoadSession.mockClear();
+	mockAcpCreateSession.mockClear();
+	mockGetAgentDefinition.mockClear();
+	mockExists.mockClear();
+	mockReadTextFile.mockClear();
+	mockCreateCommand.mockClear();
+	mockFetch.mockClear();
+	mockGetGitHubToken.mockClear();
+	spawnExitCodes.length = 0;
+	executeResults.length = 0;
+	fetchResponses.length = 0;
+
+	mockGetAgentTask.mockImplementation(async () => ({ ...baseTask }));
+	mockAcpLoadSession.mockImplementation(async () => makeSessionHandle("sess-1"));
+	mockAcpCreateSession.mockImplementation(async () => makeSessionHandle("sess-new"));
+	mockExists.mockImplementation(async () => false);
+	mockGetGitHubToken.mockImplementation(async () => "test-token");
+});
+
+// ---------------------------------------------------------------------------
+// Guards
+// ---------------------------------------------------------------------------
+
+describe("openPullRequest — guards", () => {
+	test("throws when task not found", async () => {
+		mockGetAgentTask.mockImplementation(async () => null);
+		await expect(openPullRequest("t1")).rejects.toThrow("not found");
+	});
+
+	test("throws when worktreePath is missing", async () => {
+		mockGetAgentTask.mockImplementation(async () => ({ ...baseTask, worktreePath: undefined }));
+		await expect(openPullRequest("t1")).rejects.toThrow("no worktree path");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Push failure
+// ---------------------------------------------------------------------------
+
+describe("openPullRequest — push failure", () => {
+	test("throws PushError when git push exits non-zero", async () => {
+		spawnExitCodes.push(1);
+
+		await expect(openPullRequest("t1")).rejects.toBeInstanceOf(PushError);
+	});
+
+	test("does NOT update status when push fails", async () => {
+		spawnExitCodes.push(1);
+
+		await openPullRequest("t1").catch(() => {});
+
+		const updateCalls = mockUpdateAgentTask.mock.calls as unknown as Array<
+			[string, Record<string, unknown>]
+		>;
+		const statusUpdates = updateCalls.filter(([, u]) => "status" in u);
+		expect(statusUpdates).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("openPullRequest — success", () => {
+	test("transitions to pr_open and stores prUrl", async () => {
+		pushSuccessGitResults();
+		pushSuccessFetchResults();
+
+		await openPullRequest("t1");
+
+		const updateCalls = mockUpdateAgentTask.mock.calls as unknown as Array<
+			[string, Record<string, unknown>]
+		>;
+		const prOpenUpdate = updateCalls.find(([, u]) => u.status === "pr_open");
+		expect(prOpenUpdate).toBeDefined();
+		expect(prOpenUpdate?.[1].prUrl).toBe("https://github.com/acme/app/pull/99");
+	});
+
+	test("calls GitHub PR creation API with correct fields", async () => {
+		pushSuccessGitResults();
+		pushSuccessFetchResults();
+
+		await openPullRequest("t1");
+
+		const fetchCalls = mockFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+		const prCall = fetchCalls.find(([url]) => url.includes("/pulls"));
+		expect(prCall).toBeDefined();
+
+		const body = JSON.parse(prCall![1].body as string);
+		expect(body.title).toBe("Add feature X");
+		expect(body.head).toBe("ai/t1");
+		expect(body.base).toBe("main");
+		expect(body.draft).toBe(false);
+	});
+
+	test("generates PR description via ACP and passes it as PR body", async () => {
+		pushSuccessGitResults();
+		pushSuccessFetchResults();
+
+		await openPullRequest("t1");
+
+		expect(mockAcpLoadSession).toHaveBeenCalledTimes(1);
+
+		const fetchCalls = mockFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+		const prCall = fetchCalls.find(([url]) => url.includes("/pulls"));
+		const body = JSON.parse(prCall![1].body as string);
+		expect(body.body).toContain("## Summary");
+	});
+
+	test("uses acpCreateSession when task has no acpSessionId", async () => {
+		mockGetAgentTask.mockImplementation(async () => ({ ...baseTask, acpSessionId: undefined }));
+		pushSuccessGitResults();
+		pushSuccessFetchResults();
+
+		await openPullRequest("t1");
+
+		expect(mockAcpCreateSession).toHaveBeenCalledTimes(1);
+		expect(mockAcpLoadSession).not.toHaveBeenCalled();
+	});
+
+	test("disposes ACP session after description generation", async () => {
+		const session = makeSessionHandle("sess-1");
+		mockAcpLoadSession.mockImplementation(async () => session);
+		pushSuccessGitResults();
+		pushSuccessFetchResults();
+
+		await openPullRequest("t1");
+
+		expect(session.dispose).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// PR labels
+// ---------------------------------------------------------------------------
+
+// Makes mockExists return true only for repo settings paths (so workspace settings
+// falls back to defaults, while repo settings reads the custom TOML content)
+function mockRepoSettingsFile(toml: string) {
+	mockExists.mockImplementation(
+		(async (path: unknown) => String(path).includes("_settings")) as () => Promise<boolean>,
+	);
+	mockReadTextFile.mockImplementation(async () => toml);
+}
+
+describe("openPullRequest — labels", () => {
+	test("adds labels when pr_labels configured", async () => {
+		mockRepoSettingsFile(`repo = "acme/app"\npr_labels = ["ai-generated"]`);
+		pushSuccessGitResults();
+		pushSuccessFetchResults({ labels: true });
+
+		await openPullRequest("t1");
+
+		const fetchCalls = mockFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+		const labelsCall = fetchCalls.find(([url]) => url.includes("/labels"));
+		expect(labelsCall).toBeDefined();
+
+		const body = JSON.parse(labelsCall![1].body as string);
+		expect(body.labels).toEqual(["ai-generated"]);
+	});
+
+	test("does not call labels API when pr_labels is empty", async () => {
+		pushSuccessGitResults();
+		pushSuccessFetchResults();
+
+		await openPullRequest("t1");
+
+		const fetchCalls = mockFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+		const labelsCall = fetchCalls.find(([url]) => url.includes("/labels"));
+		expect(labelsCall).toBeUndefined();
+	});
+
+	test("creates draft PR when pr_draft = true", async () => {
+		mockRepoSettingsFile(`repo = "acme/app"\npr_draft = true`);
+		pushSuccessGitResults();
+		pushSuccessFetchResults();
+
+		await openPullRequest("t1");
+
+		const fetchCalls = mockFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+		const prCall = fetchCalls.find(([url]) => url.includes("/pulls"));
+		const body = JSON.parse(prCall![1].body as string);
+		expect(body.draft).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Ticket transition
+// ---------------------------------------------------------------------------
+
+describe("openPullRequest — ticket transition", () => {
+	test("calls GitHub Projects transition when sourceItemId and on_pr_open are set", async () => {
+		mockGetAgentTask.mockImplementation(async () => ({
+			...baseTask,
+			sourceItemId: "PVTI_abc123",
+		}));
+		mockRepoSettingsFile(
+			`repo = "acme/app"\ngithub_project_number = 5\n[transitions]\non_pr_open = "In Review"`,
+		);
+
+		pushSuccessGitResults();
+		pushSuccessFetchResults();
+		// STATUS_FIELD_QUERY response
+		fetchResponses.push({
+			ok: true,
+			status: 200,
+			body: {
+				data: {
+					repositoryOwner: {
+						projectV2: {
+							id: "PV_123",
+							field: {
+								id: "PVTSSF_456",
+								options: [{ id: "opt_1", name: "In Review" }],
+							},
+						},
+					},
+				},
+			},
+		});
+		// TRANSITION_MUTATION response
+		fetchResponses.push({
+			ok: true,
+			status: 200,
+			body: { data: { updateProjectV2ItemFieldValue: { projectV2Item: { id: "PVTI_abc123" } } } },
+		});
+
+		await openPullRequest("t1");
+
+		const fetchCalls = mockFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+		const graphqlCalls = fetchCalls.filter(([url]) => url.includes("graphql"));
+		expect(graphqlCalls.length).toBeGreaterThanOrEqual(2);
+
+		const mutationCall = graphqlCalls[graphqlCalls.length - 1];
+		const body = JSON.parse(mutationCall[1].body as string);
+		expect(body.variables.itemId).toBe("PVTI_abc123");
+		expect(body.variables.optionId).toBe("opt_1");
+	});
+
+	test("skips transition when sourceItemId is absent", async () => {
+		mockRepoSettingsFile(
+			`repo = "acme/app"\ngithub_project_number = 5\n[transitions]\non_pr_open = "In Review"`,
+		);
+
+		pushSuccessGitResults();
+		pushSuccessFetchResults();
+
+		// No sourceItemId on task → transition should be skipped
+		await openPullRequest("t1");
+
+		const fetchCalls = mockFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+		const graphqlCalls = fetchCalls.filter(([url]) => url.includes("graphql"));
+		expect(graphqlCalls).toHaveLength(0);
+	});
+
+	test("skips transition when on_pr_open is not configured", async () => {
+		mockGetAgentTask.mockImplementation(async () => ({
+			...baseTask,
+			sourceItemId: "PVTI_abc123",
+		}));
+
+		pushSuccessGitResults();
+		pushSuccessFetchResults();
+
+		// No transitions config → skip
+		await openPullRequest("t1");
+
+		const fetchCalls = mockFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+		const graphqlCalls = fetchCalls.filter(([url]) => url.includes("graphql"));
+		expect(graphqlCalls).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Failure after push
+// ---------------------------------------------------------------------------
+
+describe("openPullRequest — post-push failures", () => {
+	test("sets status to failed when PR creation fails", async () => {
+		pushSuccessGitResults();
+		fetchResponses.push({ ok: false, status: 422, body: { message: "Validation failed" } });
+
+		await expect(openPullRequest("t1")).rejects.toThrow("422");
+
+		const updateCalls = mockUpdateAgentTask.mock.calls as unknown as Array<
+			[string, Record<string, unknown>]
+		>;
+		const failUpdate = updateCalls.find(([, u]) => u.status === "failed");
+		expect(failUpdate).toBeDefined();
+	});
+});

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -173,6 +173,9 @@ export async function getResolvedConfig(
 		ai_backend: workspace.ai_backend,
 		editor: workspace.editor,
 		plan_review: workspace.plan_review ?? true,
+		pr_labels: [],
+		pr_draft: false,
+		transitions: {},
 	};
 
 	if (owner && repo) {
@@ -183,6 +186,15 @@ export async function getResolvedConfig(
 			}
 			if (repoSettings.editor !== undefined) {
 				resolved.editor = repoSettings.editor;
+			}
+			if (repoSettings.pr_labels !== undefined) {
+				resolved.pr_labels = repoSettings.pr_labels;
+			}
+			if (repoSettings.pr_draft !== undefined) {
+				resolved.pr_draft = repoSettings.pr_draft;
+			}
+			if (repoSettings.transitions !== undefined) {
+				resolved.transitions = repoSettings.transitions;
 			}
 		}
 	}

--- a/src/services/executor.ts
+++ b/src/services/executor.ts
@@ -84,6 +84,14 @@ export async function executeTask(taskId: string, onLine?: LogCallback): Promise
 	await updateAgentTask(taskId, { status: "pushing" });
 }
 
+// Runs the full task pipeline: agent execution followed by branch push and PR creation.
+// Callers should use this rather than calling executeTask and openPullRequest separately.
+export async function runTaskPipeline(taskId: string, onLine?: LogCallback): Promise<void> {
+	const { openPullRequest } = await import("@/services/pr-service");
+	await executeTask(taskId, onLine);
+	await openPullRequest(taskId, onLine);
+}
+
 export async function retryTask(taskId: string, onLine?: LogCallback): Promise<void> {
 	const task = await getAgentTask(taskId);
 	if (!task) throw new Error(`Task ${taskId} not found`);

--- a/src/services/github-projects.ts
+++ b/src/services/github-projects.ts
@@ -173,8 +173,8 @@ function mapIssueNode(node: Record<string, unknown>): Task | null {
 // ---------------------------------------------------------------------------
 
 export class GitHubProjectsSource implements TicketSource {
-	private _owner: string | null = null;
-	private _projectNumber: number | null = null;
+	private readonly _owner: string;
+	private readonly _projectNumber: number;
 	private _statusCache: {
 		projectId: string;
 		fieldId: string;
@@ -182,19 +182,20 @@ export class GitHubProjectsSource implements TicketSource {
 	} | null = null;
 	private readonly _getToken: () => Promise<string | null>;
 
-	constructor(getToken: () => Promise<string | null> = defaultGetToken) {
+	constructor(
+		owner: string,
+		projectNumber: number,
+		getToken: () => Promise<string | null> = defaultGetToken,
+	) {
+		this._owner = owner;
+		this._projectNumber = projectNumber;
 		this._getToken = getToken;
 	}
 
 	async fetchTasks(repoSettings: RepoSettings): Promise<Task[]> {
-		if (!repoSettings.github_project_number) return [];
-
 		const token = await this._getToken();
 		if (!token) return [];
 
-		const [owner] = repoSettings.repo.split("/");
-		this._owner = owner;
-		this._projectNumber = repoSettings.github_project_number;
 		this._statusCache = null;
 
 		const tasks: Task[] = [];
@@ -202,12 +203,12 @@ export class GitHubProjectsSource implements TicketSource {
 
 		do {
 			const data = await graphqlRequest(token, PROJECT_ITEMS_QUERY, {
-				owner,
-				projectNumber: repoSettings.github_project_number,
+				owner: this._owner,
+				projectNumber: this._projectNumber,
 				cursor,
 			});
 
-			const project = extractProject(data, owner, repoSettings.github_project_number);
+			const project = extractProject(data, this._owner, this._projectNumber);
 			const items = project.items as Record<string, unknown>;
 			const pageInfo = items.pageInfo as { hasNextPage: boolean; endCursor: string };
 			const nodes = (items.nodes as Array<Record<string, unknown>>) ?? [];
@@ -228,11 +229,7 @@ export class GitHubProjectsSource implements TicketSource {
 		return tasks;
 	}
 
-	async transitionTask(taskId: string, status: string): Promise<void> {
-		if (!this._owner || !this._projectNumber) {
-			throw new Error("fetchTasks must be called before transitionTask");
-		}
-
+	async transitionTask(itemId: string, status: string): Promise<void> {
 		const token = await this._getToken();
 		if (!token) throw new GitHubAuthError("No GitHub token configured");
 
@@ -270,7 +267,7 @@ export class GitHubProjectsSource implements TicketSource {
 
 		await graphqlRequest(token, TRANSITION_MUTATION, {
 			projectId: this._statusCache.projectId,
-			itemId: taskId,
+			itemId,
 			fieldId: this._statusCache.fieldId,
 			optionId,
 		});

--- a/src/services/pr-service.ts
+++ b/src/services/pr-service.ts
@@ -1,0 +1,241 @@
+import { getAgentTask, updateAgentTask } from "@/lib/agentTaskRepository";
+import { getGitHubToken } from "@/services/github-auth";
+import { acpCreateSession, acpLoadSession } from "@/services/acpService";
+import { getResolvedConfig, readRepoSettings } from "@/services/configService";
+import { GitHubProjectsSource } from "@/services/github-projects";
+import { getDiffStat, getCommitMessages, pushBranch } from "@/services/git";
+import { emitSystemLog } from "@/services/logStreamService";
+import { getAgentDefinition } from "@/lib/agents";
+import type { AcpSessionHandle } from "@/services/acpService";
+import type { ProcessEvent } from "@/types/logs";
+
+export type LogCallback = (event: ProcessEvent) => void;
+
+export class PushError extends Error {
+	constructor(message: string, public readonly cause?: Error) {
+		super(message);
+		this.name = "PushError";
+	}
+}
+
+const PR_DESCRIPTION_PROMPT = (
+	title: string,
+	description: string,
+	commitMessages: string[],
+	filesChanged: number,
+	insertions: number,
+	deletions: number,
+	sourceUrl?: string,
+) => `Task: ${title}
+Description: ${description}
+Commits:
+${commitMessages.map((m) => `- ${m}`).join("\n")}
+Files changed: ${filesChanged} (${insertions}+, ${deletions}-)
+
+Write a GitHub pull request description using exactly this format:
+
+## Summary
+- <bullet>
+
+## Changes
+<key technical decisions>
+
+## Testing
+<what was tested>
+${sourceUrl ? `\nCloses ${sourceUrl}` : ""}`;
+
+async function generatePrDescription(
+	worktreePath: string,
+	acpSessionId: string | undefined,
+	agentDef: { acpCommand: string; acpArgs: string[] },
+	prompt: string,
+): Promise<string> {
+	let session: AcpSessionHandle | undefined;
+
+	try {
+		if (acpSessionId) {
+			session = await acpLoadSession(acpSessionId, worktreePath, agentDef.acpCommand, agentDef.acpArgs);
+		} else {
+			session = await acpCreateSession(worktreePath, agentDef.acpCommand, agentDef.acpArgs);
+		}
+
+		const chunks: string[] = [];
+
+		const unsubscribe = session.subscribe((agentEvent) => {
+			if (agentEvent.event.type !== "message_chunk") return;
+			chunks.push(agentEvent.event.text);
+		});
+
+		await session.send(prompt);
+		unsubscribe();
+
+		return chunks.join("").trim();
+	} finally {
+		await session?.dispose();
+	}
+}
+
+interface GitHubPrResponse {
+	number: number;
+	html_url: string;
+}
+
+async function createGitHubPr(opts: {
+	owner: string;
+	repo: string;
+	token: string;
+	title: string;
+	body: string;
+	head: string;
+	base: string;
+	draft: boolean;
+}): Promise<GitHubPrResponse> {
+	const response = await fetch(`https://api.github.com/repos/${opts.owner}/${opts.repo}/pulls`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${opts.token}`,
+			"Content-Type": "application/json",
+			Accept: "application/vnd.github+json",
+		},
+		body: JSON.stringify({
+			title: opts.title,
+			body: opts.body,
+			head: opts.head,
+			base: opts.base,
+			draft: opts.draft,
+		}),
+	});
+
+	if (!response.ok) {
+		const text = await response.text().catch(() => response.statusText);
+		throw new Error(`GitHub PR creation failed (${response.status}): ${text}`);
+	}
+
+	return response.json() as Promise<GitHubPrResponse>;
+}
+
+async function addGitHubLabels(
+	owner: string,
+	repo: string,
+	prNumber: number,
+	labels: string[],
+	token: string,
+): Promise<void> {
+	if (labels.length === 0) return;
+
+	const response = await fetch(
+		`https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/labels`,
+		{
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+				Accept: "application/vnd.github+json",
+			},
+			body: JSON.stringify({ labels }),
+		},
+	);
+
+	if (!response.ok) {
+		const text = await response.text().catch(() => response.statusText);
+		throw new Error(`Failed to add labels (${response.status}): ${text}`);
+	}
+}
+
+export async function openPullRequest(taskId: string, onLine?: LogCallback): Promise<void> {
+	const task = await getAgentTask(taskId);
+	if (!task) throw new Error(`Task ${taskId} not found`);
+	if (!task.worktreePath) throw new Error(`Task ${taskId} has no worktree path`);
+
+	const { worktreePath, owner, repo, baseBranch, branchName, workspacePath } = task;
+
+	const config = await getResolvedConfig(workspacePath, owner, repo);
+	const agentDef = getAgentDefinition(config.ai_backend);
+
+	// Step 1: Push branch — failure stays in `pushing` for retry
+	await emitSystemLog(taskId, "Pushing branch...", onLine);
+	try {
+		await pushBranch({ worktreePath, remote: "origin", branchName, taskId, onLine: onLine ?? (() => {}) });
+	} catch (err) {
+		throw new PushError(
+			`Failed to push branch: ${err instanceof Error ? err.message : String(err)}`,
+			err instanceof Error ? err : undefined,
+		);
+	}
+
+	try {
+		// Step 2: Gather commit info for PR description
+		const [commitMessages, diffStat] = await Promise.all([
+			getCommitMessages(worktreePath, baseBranch),
+			getDiffStat(worktreePath, baseBranch),
+		]);
+
+		// Step 3: Generate PR description via ACP session
+		await emitSystemLog(taskId, "Generating PR description...", onLine);
+		const descriptionPrompt = PR_DESCRIPTION_PROMPT(
+			task.title,
+			task.description,
+			commitMessages,
+			diffStat.filesChanged,
+			diffStat.insertions,
+			diffStat.deletions,
+			task.sourceUrl,
+		);
+		const prBody = await generatePrDescription(
+			worktreePath,
+			task.acpSessionId,
+			agentDef,
+			descriptionPrompt,
+		);
+
+		// Step 4: Create PR via GitHub REST API
+		await emitSystemLog(taskId, "Creating pull request...", onLine);
+		const token = await getGitHubToken();
+		if (!token) throw new Error("No GitHub token configured");
+
+		const pr = await createGitHubPr({
+			owner,
+			repo,
+			token,
+			title: task.title,
+			body: prBody,
+			head: branchName,
+			base: baseBranch,
+			draft: config.pr_draft,
+		});
+
+		// Step 5: Apply labels if configured
+		if (config.pr_labels.length > 0) {
+			await addGitHubLabels(owner, repo, pr.number, config.pr_labels, token).catch((err) => {
+				console.error("Failed to add PR labels (non-fatal):", err);
+			});
+		}
+
+		// Step 6: Update task status
+		await updateAgentTask(taskId, { status: "pr_open", prUrl: pr.html_url });
+
+		// Step 7: Transition source ticket if configured
+		if (
+			task.sourceProvider === "github_projects" &&
+			task.sourceItemId &&
+			config.transitions.on_pr_open
+		) {
+			const repoSettings = await readRepoSettings(workspacePath, owner, repo);
+			if (repoSettings?.github_project_number) {
+				await new GitHubProjectsSource(owner, repoSettings.github_project_number)
+					.transitionTask(task.sourceItemId, config.transitions.on_pr_open)
+					.catch((err) => {
+						console.error("Failed to transition source ticket (non-fatal):", err);
+					});
+			}
+		}
+
+		await emitSystemLog(taskId, `PR opened: ${pr.html_url}`, onLine);
+	} catch (err) {
+		await updateAgentTask(taskId, {
+			status: "failed",
+			error: err instanceof Error ? err.message : String(err),
+		});
+		throw err;
+	}
+}

--- a/src/types/agent-task.ts
+++ b/src/types/agent-task.ts
@@ -20,6 +20,7 @@ export interface AgentTask {
 	description: string;
 	sourceUrl?: string;
 	sourceProvider?: string;
+	sourceItemId?: string;
 	// Denormalized from projects JOIN — read-only on the task
 	workspacePath: string;
 	repoPath: string;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -37,6 +37,9 @@ export const RepoSettingsSchema = z.object({
 	github_project_number: z.number().int().positive().optional(),
 	labels: z.array(z.string()).optional(),
 	auto_grab: z.boolean().optional(),
+	pr_labels: z.array(z.string()).optional(),
+	pr_draft: z.boolean().optional(),
+	transitions: z.object({ on_pr_open: z.string().optional() }).optional(),
 });
 
 export type RepoSettings = z.infer<typeof RepoSettingsSchema>;
@@ -50,6 +53,9 @@ export type ResolvedConfig = {
 	ai_backend: AIBackend;
 	editor?: Editor;
 	plan_review: boolean;
+	pr_labels: string[];
+	pr_draft: boolean;
+	transitions: { on_pr_open?: string };
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Creates `pr-service.ts` with `openPullRequest` that pushes branch, generates PR description via ACP session, creates GitHub PR via REST API, applies labels, and transitions source tickets in GitHub Projects
- Refactors `GitHubProjectsSource` to accept `owner` and `projectNumber` at construction so `transitionTask` works standalone without requiring `fetchTasks` first
- Adds `sourceItemId` field to `agent_tasks` (DB migration v4) to store the GitHub Projects item ID needed for GraphQL transitions

## Changes
- `pr-service.ts`: Full PR creation pipeline with `PushError` to distinguish push failures (task stays in `pushing`) from post-push failures (task goes to `failed`); ticket transition is non-fatal
- `github-projects.ts`: Constructor refactored from `(getToken?)` to `(owner, projectNumber, getToken?)` with lazy default token import to avoid `LazyStore` singleton issues in tests
- `executor.ts`: Added `runTaskPipeline` that chains `executeTask` → `openPullRequest` using dynamic import to prevent module registry leakage in the test suite
- `types/config.ts` + `configService.ts`: Added `pr_labels`, `pr_draft`, and `transitions.on_pr_open` config fields resolved from workspace → repo settings hierarchy
- DB migration v4: `ALTER TABLE agent_tasks ADD COLUMN source_item_id TEXT`

## Testing
- 16 new tests in `pr-service.test.ts` covering guards, push failures, happy path, labels, draft PRs, ticket transitions (present/absent), and post-push failure status
- Updated `github-projects.test.ts` for new constructor signature (removed now-obsolete "returns [] when not configured" test since project number is required at construction)
- All 142 service/store/lib tests pass; 0 TypeScript errors
- 5 pre-existing failures in `workspaceListService.test.ts` when run after `CreateWorkspacePage.test.tsx` are unrelated cross-contamination (existed before this branch)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)